### PR TITLE
Fix wizard and invalid tool index issues

### DIFF
--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -23,9 +23,13 @@ if { #tools > 0 && tools[param.P].spindle != -1 }
     abort { "Tool #" ^ param.P ^ " is already defined." }
 
 ; Define RRF tool against spindle.
-M563 P{param.P} S{param.S} R{global.mosSpindleID}
+; Allow spindle ID to be overridden where necessary using I parameter.
+M563 P{param.P} S{param.S} R{(exists(param.I)) ? param.I : global.mosSpindleID}
 
 ; Store tool description in zero-indexed array.
-set global.mosToolTable[param.P] = {param.R, false, {0, 0}}
+set global.mosToolTable[param.P] = { global.mosEmptyTool }
+
+; Set tool radius
+set global.mosToolTable[param.P][0] = { param.R }
 
 M7500 S{"Stored tool #" ^ param.P ^ " R=" ^ param.R ^ " S=" ^ param.S}

--- a/macro/machine/M4001.g
+++ b/macro/machine/M4001.g
@@ -6,13 +6,18 @@
 if { !exists(param.P) }
     abort "Must provide tool number (P...) to remove from tool list!"
 
+; Before any tools are defined, the tool table is empty.
+if { #tools < 1 }
+    M99
+
 var maxTools = { limits.tools-1 }
 
 if { param.P > var.maxTools || param.P < 0 }
     abort { "Tool index must be between 0 and " ^  var.maxTools ^ "!" }
 
-if { #tools > 0 && tools[param.P].spindle != global.mosSpindleID }
-    abort { "Tool #" ^ param.P ^ " is not assigned to the configured spindle, ID #" ^ global.mosSpindleID ^ "!" }
+; Check if the tool exists
+if { tools[param.P] == null }
+    M99
 
 ; Reset RRF Tool
 M563 P{param.P} R-1 S"Unknown Tool"

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -34,16 +34,13 @@ set global.mosWorkPieceCenterPos = { null, null }
 if { global.mosProbeToolID != state.currentTool }
     T T{global.mosProbeToolID}
 
-; Tool Radius is the first entry for each value in
-; our extended tool table.
-
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact
 ; with the surface based on the tool radius.
 ; For big tools and low overtravel values, this value
 ; might end up being negative. This is fine, as long
 ; as the configured tool radius is accurate.
-var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - global.mosToolTable[state.currentTool][0] }
+var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 M7500 S{"Distance Modifiers adjusted for Tool Radius - Overtravel=" ^ var.overtravel }
 

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -37,7 +37,7 @@ if { global.mosProbeToolID != state.currentTool }
 ; Apply tool radius to clearance. We want to make sure
 ; the surface of the tool and the workpiece are the
 ; clearance distance apart, rather than less than that.
-var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + global.mosToolTable[state.currentTool][0] }
+var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact
@@ -45,7 +45,7 @@ var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + globa
 ; For big tools and low overtravel values, this value
 ; might end up being negative. This is fine, as long
 ; as the configured tool radius is accurate.
-var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - global.mosToolTable[state.currentTool][0] }
+var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 M7500 S{"Distance Modifiers adjusted for Tool Radius - Clearance=" ^ var.clearance ^ " Overtravel=" ^ var.overtravel }
 

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -59,7 +59,7 @@ var hL   = { var.fL/2 }
 ; Apply tool radius to clearance. We want to make sure
 ; the surface of the tool and the workpiece are the
 ; clearance distance apart, rather than less than that.
-var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + global.mosToolTable[state.currentTool][0] }
+var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact
@@ -67,7 +67,7 @@ var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + globa
 ; For big tools and low overtravel values, this value
 ; might end up being negative. This is fine, as long
 ; as the configured tool radius is accurate.
-var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - global.mosToolTable[state.currentTool][0] }
+var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Check that the clearance distance isn't
 ; higher than the width or height of the block.

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -52,7 +52,7 @@ var fY   = { param.I }
 ; Apply tool radius to clearance. We want to make sure
 ; the surface of the tool and the workpiece are the
 ; clearance distance apart, rather than less than that.
-var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + global.mosToolTable[state.currentTool][0] }
+var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact
@@ -60,7 +60,7 @@ var clearance = { (exists(param.T) ? param.T : global.mosProbeClearance) + globa
 ; For big tools and low overtravel values, this value
 ; might end up being negative. This is fine, as long
 ; as the configured tool radius is accurate.
-var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - global.mosToolTable[state.currentTool][0] }
+var overtravel = { (exists(param.O) ? param.O : global.mosProbeOvertravel) - ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Check that the clearance distance isn't
 ; higher than the width or height of the block.

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -18,12 +18,12 @@ if { !exists(param.I) }
 
 var probeId = { global.mosFeatureTouchProbe ? global.mosTouchProbeID : null }
 
+set global.mosWorkPieceSurfacePos = null
+set global.mosWorkPieceSurfaceAxis = null
+
 ; Make sure probe tool is selected
 if { global.mosProbeToolID != state.currentTool }
     T T{global.mosProbeToolID}
-
-set global.mosWorkPieceSurfacePos = null
-set global.mosWorkPieceSurfaceAxis = null
 
 var safeZ = { move.axes[2].machinePosition }
 
@@ -39,8 +39,8 @@ var sZ   = { param.L }
 ; Z probes as well as X/Y. Tool radius only applies for X/Y probes.
 var overtravel = { exists(param.O) ? param.O : global.mosProbeOvertravel }
 
-; Tool Radius
-var tR = { global.mosToolTable[state.currentTool][0] }
+; Tool Radius if tool is selected
+var tR = { ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosToolTable[state.currentTool][0] : 0) }
 
 ; Set target positions
 var tPX = { var.sX }

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -143,6 +143,8 @@ else
 if { !exists(param.D) }
     G6550 I{ param.I } Z{ var.safeZ }
 
+M400
+
 ; Calculate tool radius and round the output.
 ; We round to 3 decimal places (0.001mm) which is
 ; way more than we actually need, because 1.8 degree
@@ -154,15 +156,11 @@ if { !exists(param.D) }
 ; tool radius and deflection.
 
 ; The tool radius we use here already includes a deflection value
-; which is deemed to be the same for each axis.
+; which is deemed to be the same for each X/Y axis.
 ; TODO: Is this a safe assumption?
-
-var tI = { state.currentTool }
-var validTool = { var.tI <= limits.tools-1 && var.tI >= 0 }
-
-if { var.validTool }
-    ; Get tool radius minus applicable deflection from tool table, or 0 if no tool is selected
-    var toolRadius = { (var.validTool)? global.mosToolTable[state.currentTool][0] : 0 }
+if { state.currentTool <= limits.tools-1 && state.currentTool >= 0 }
+    ; Get tool radius minus applicable deflection from tool table
+    var toolRadius = { global.mosToolTable[state.currentTool][0] }
 
     M7500 S{"Compensating for tool radius of " ^ var.toolRadius ^ "mm."}
 
@@ -184,9 +182,8 @@ if { var.validTool }
     ; in X/Y, _or_ Z, and we have some control over this as we're writing the higher
     ; level macros.
 
-else
-    if { !global.mosExpertMode }
-        echo { "No tool selected, cannot compensate for tool radius. Select a tool before probing to apply tool radius compensation." }
+elif { !global.mosExpertMode }
+    echo { "No tool selected, cannot compensate for tool radius. Select a tool before probing to apply tool radius compensation." }
 
 ; Multiply, ceil then divide by this number
 ; to achieve 3 decimal places of accuracy.

--- a/macro/private/display-startup-messages.g
+++ b/macro/private/display-startup-messages.g
@@ -10,9 +10,15 @@ if { !exists(global.mosStartupMsgsDisplayed) }
 if { !global.mosStartupMsgsDisplayed }
     set global.mosStartupMsgsDisplayed = true
     if {(!exists(global.mosLoaded) || !global.mosLoaded)}
-        var startupError = { (exists(global.mosStartupError) && global.mosStartupError != null) ? global.mosStartupError : "Unknown error. Have you added <b>M98 P""mos.g""</b> at the bottom of your <b>config.g</b>?" }
-        M291 P{ var.startupError } R"MillenniumOS: Startup Error" S2 T10
-        M99
+        ; We can't load MOS without a mos-user-vars.g file so there's no point
+        ; reporting an error when we know what it is.
+        if { !fileexists("0:/sys/mos-user-vars.g") }
+            echo { "No user configuration file found. Run the configuration wizard with <b>G8000</b> to silence this warning. MillenniumOS is not loaded." }
+            M99
+        else
+            var startupError = { (exists(global.mosStartupError) && global.mosStartupError != null) ? global.mosStartupError : "Unknown error. Have you added <b>M98 P""mos.g""</b> at the bottom of your <b>config.g</b>?" }
+            M291 P{ var.startupError } R"MillenniumOS: Startup Error" S2 T10
+            M99
     else
         if { !global.mosExpertMode }
             echo { "MillenniumOS: Loaded " ^ global.mosVersion }

--- a/macro/public/3. Config/Settings/Toggle Toolsetter.g
+++ b/macro/public/3. Config/Settings/Toggle Toolsetter.g
@@ -7,6 +7,10 @@ if { global.mosFeatureToolSetter }
     if { result == -1 }
         M99
 
+if { global.mosToolSetterID == null || global.mosToolSetterPos == null }
+    M291 R"MillenniumOS: Toggle Toolsetter" P"Toolsetter has not been configured. Please configure the toolsetter using the Configuration Wizard first." S2
+    M99
+
 set global.mosFeatureToolSetter = {!global.mosFeatureToolSetter}
 
 echo {"MillenniumOS: Toolsetter " ^ (global.mosFeatureToolSetter ? "Enabled" : "Disabled")}

--- a/macro/public/3. Config/Settings/Toggle Touch Probe.g
+++ b/macro/public/3. Config/Settings/Toggle Touch Probe.g
@@ -7,6 +7,11 @@ if { global.mosFeatureTouchProbe }
     if { result == -1 }
         M99
 
+; These 3 values are required for touch probe use.
+if { global.mosTouchProbeID == null || global.mosTouchProbeReferencePos == null || global.mosTouchProbeRadius == null  }
+    M291 R"MillenniumOS: Toggle Touch Probe" P"Touch Probe has not been configured. Please configure the touch probe using the Configuration Wizard first." S2
+    M99
+
 set global.mosFeatureTouchProbe = {!global.mosFeatureTouchProbe}
 
 ; Switch probe tool name and configuration when toggling touch probe

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -50,7 +50,6 @@ global mosEmptyTool = { 0.0, }
 global mosToolTable = { vector(limits.tools, global.mosEmptyTool) }
 
 ; Coordinates returned by the most recent probing operation.
-global mosProbeComplete=false
 global mosProbeCoordinate={ null, null, null }
 global mosProbeVariance={ null, null, null }
 


### PR DESCRIPTION
RC1 did as expected - identified a bunch of issues on first-contact with a real user. Unfortunately they were in the Wizard process, the first interaction that a new user would have with MOS 🤦

We fix these issues in various different manners, but mostly by checking to make sure that a tool is currently selected before trying to read the tool radius. If no tool is selected then we do not perform radius compensation during probing operations.

To get around tool limitations in the Wizard (before MOS is properly configured, which is necessary for correct tool changes), we temporarily create and delete probe tools so we can run the steps necessary to calibrate the touch probe, datum tool and toolsetter.

Finally, we add some checks so that Toolsetter and Touch Probe cannot be toggled if they have not yet been configured in the Wizard.

Many thanks to @MrSniperPhil for being the guineapig and putting his Milo and probe tips on the line for this!