### PR TITLE
Validate RRF tool table indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ We build _on top of_ RepRapFirmware, providing operators of the Millennium Machi
   - Install one of the post-processors from [here](./post-processors/) into your CAM tool of choice.
 
 ## Notes
-  - You _must_ be using RRF `v3.5.0-rc.2` or above. MOS uses many 'meta gcode' features that do not exist in earlier versions.
+  - You _must_ be using RRF `v3.5.0-rc.1` or above. MOS uses many 'meta gcode' features that do not exist in earlier versions.
+  - If you are using RRF `v3.5.0-rc.2` or below and cannot easily upgrade, you should add `set global.mosProbePositionDelay=350` to the bottom of your `mos-user-vars.g` file after running the Configuration Wizard. There is a bug in v3.5.0-rc.2 and below that causes machine positions to not be reported accurately without at least a 200ms delay after the machine stops moving. This will cause protected probe moves and probe positions to be innaccurate. The simpler fix is just to update RRF.
   - MOS includes its own `daemon.g` file to implement repetitive tasks, such as VSSC. If you want to implement your own repetitive tasks, you should create a `user-daemon.g` file in the `/sys` directory, which MillenniumOS will run during its' own daemon loop. Disabling the MOS daemon tasks will also disable any `user-daemon.g` tasks. Do not use any long-running loops inside `user-daemon.g` as this will interfere with MOS's own daemon behaviour.
 
 ## RRF Config
@@ -58,6 +59,8 @@ M558 K1 P8 C"xstopmax" H10 A10 S0.01 T1200 F300:60
 M558 K2 P8 C"probe" H2 A10 S0.01 T1200 F300:50
 ```
 
+You will also want to remove any manual tool definitions from your configuration, as MillenniumOS manages tools through the `M4000` and `M4001` custom M-codes - remove any lines in your config.g that use the `M563` command, and also any lines which refer to tools which would have been created by these commands (e.g. `G10 P<toolnumber>`).
+
 ## Warnings
 Due to a some issues with RRF as it currently stands, there are a small number of situations where you can shoot yourself in the foot when running MillenniumOS macros outside of a print file these are:
 
@@ -67,6 +70,9 @@ Due to a some issues with RRF as it currently stands, there are a small number o
 
 ## Bugs, Issues, Support
 If you find any bugs or issues, please create an issue on this repository. Best-effort support is available via our [Discord](https://discord.gg/ya4UUj7ax2).
+
+### Troubleshooting
+To help us work out any issues, please run `M7600 D1` and paste the whole output into any issue you create, or attach with any help request in Discord. This output includes the value of MOS specific variables and also the contents of the RRF object model - specifically the limits, move, sensors, spindles, state and tool keys which are essential for debugging MillenniumOS functionality (or lack thereof).
 
 ---
 

--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -19,7 +19,7 @@ if { param.P > var.maxTools || param.P < 0 }
 
 ; Check if tool already exists. If no tools are defined, the
 ; length of the tools array is 0.
-if { #tools > 0 && tools[param.P].spindle != -1 }
+if { #tools > 0 && exists(tools[param.P]) && tools[param.P].spindle != -1 }
     abort { "Tool #" ^ param.P ^ " is already defined." }
 
 ; Define RRF tool against spindle.

--- a/macro/machine/M4001.g
+++ b/macro/machine/M4001.g
@@ -16,7 +16,7 @@ if { param.P > var.maxTools || param.P < 0 }
     abort { "Tool index must be between 0 and " ^  var.maxTools ^ "!" }
 
 ; Check if the tool exists
-if { tools[param.P] == null }
+if { !exists(tools[param.P]) || tools[param.P] == null }
     M99
 
 ; Reset RRF Tool

--- a/macro/machine/M7600.g
+++ b/macro/machine/M7600.g
@@ -9,47 +9,54 @@
 ; use these variables in your own macro calls to implement custom
 ; functionality.
 
-echo { "MOS Features:" }
-echo { "  global.mosFeatureToolSetter=" ^ global.mosFeatureToolSetter }
-echo { "  global.mosFeatureTouchProbe=" ^ global.mosFeatureTouchProbe }
-echo { "  global.mosFeatureSpindleFeedback=" ^ global.mosFeatureSpindleFeedback }
-echo { "  global.mosFeatureVSSC=" ^ global.mosFeatureVSSC }
-echo { "===" }
+echo { "=== MOS Features:" }
+echo { "      global.mosFeatureToolSetter=" ^ global.mosFeatureToolSetter }
+echo { "      global.mosFeatureTouchProbe=" ^ global.mosFeatureTouchProbe }
+echo { "      global.mosFeatureSpindleFeedback=" ^ global.mosFeatureSpindleFeedback }
+echo { "      global.mosFeatureVSSC=" ^ global.mosFeatureVSSC }
 
-echo { "MOS Probing:" }
-echo { "  global.mosProbeToolID=" ^ global.mosProbeToolID }
-echo { "  global.mosProbeDetected=" ^ global.mosProbeDetected }
-echo { "  global.mosDetectedProbeID=" ^ global.mosDetectedProbeID }
-echo { "  global.mosProbeCoordinate=" ^ global.mosProbeCoordinate }
-echo { "  global.mosProbeVariance=" ^ global.mosProbeVariance }
-echo { "  global.mosProbeOvertravel=" ^ global.mosProbeOvertravel }
-echo { "  global.mosProbePositionDelay=" ^ global.mosProbePositionDelay }
-echo { "  global.mosLastProbeCycle=" ^ global.mosLastProbeCycle }
-echo { "  global.mosWorkPieceCenterPos=" ^ global.mosWorkPieceCenterPos }
-echo { "  global.mosWorkPieceDimensions=" ^ global.mosWorkPieceDimensions }
-echo { "  global.mosWorkPieceRadius=" ^ global.mosWorkPieceRadius }
-echo { "  global.mosWorkPieceRotationAngle=" ^ global.mosWorkPieceRotationAngle }
-echo { "  global.mosWorkPieceBoundingBox=" ^ global.mosWorkPieceBoundingBox }
-echo { "  global.mosWorkPieceCornerNum=" ^ global.mosWorkPieceCornerNum }
-echo { "  global.mosWorkPieceCornerPos=" ^ global.mosWorkPieceCornerPos }
-echo { "  global.mosWorkPieceCornerAngle=" ^ global.mosWorkPieceCornerAngle }
-echo { "  global.mosWorkPieceSurfaceAxis=" ^ global.mosWorkPieceSurfaceAxis }
-echo { "  global.mosWorkPieceSurfacePos=" ^ global.mosWorkPieceSurfacePos }
-echo { "===" }
+echo { "=== MOS Probing:" }
+echo { "      global.mosProbeToolID=" ^ global.mosProbeToolID }
+echo { "      global.mosProbeDetected=" ^ global.mosProbeDetected }
+echo { "      global.mosDetectedProbeID=" ^ global.mosDetectedProbeID }
+echo { "      global.mosProbeCoordinate=" ^ global.mosProbeCoordinate }
+echo { "      global.mosProbeVariance=" ^ global.mosProbeVariance }
+echo { "      global.mosProbeOvertravel=" ^ global.mosProbeOvertravel }
+echo { "      global.mosProbePositionDelay=" ^ global.mosProbePositionDelay }
+echo { "      global.mosLastProbeCycle=" ^ global.mosLastProbeCycle }
+echo { "      global.mosWorkPieceCenterPos=" ^ global.mosWorkPieceCenterPos }
+echo { "      global.mosWorkPieceDimensions=" ^ global.mosWorkPieceDimensions }
+echo { "      global.mosWorkPieceRadius=" ^ global.mosWorkPieceRadius }
+echo { "      global.mosWorkPieceRotationAngle=" ^ global.mosWorkPieceRotationAngle }
+echo { "      global.mosWorkPieceBoundingBox=" ^ global.mosWorkPieceBoundingBox }
+echo { "      global.mosWorkPieceCornerNum=" ^ global.mosWorkPieceCornerNum }
+echo { "      global.mosWorkPieceCornerPos=" ^ global.mosWorkPieceCornerPos }
+echo { "      global.mosWorkPieceCornerAngle=" ^ global.mosWorkPieceCornerAngle }
+echo { "      global.mosWorkPieceSurfaceAxis=" ^ global.mosWorkPieceSurfaceAxis }
+echo { "      global.mosWorkPieceSurfacePos=" ^ global.mosWorkPieceSurfacePos }
 
-echo { "MOS Touch Probe:" }
-echo { "  global.mosTouchProbeID=" ^ global.mosTouchProbeID }
-echo { "  global.mosTouchProbeRadius=" ^ global.mosTouchProbeRadius }
-echo { "  global.mosTouchProbeDeflection=" ^ global.mosTouchProbeDeflection }
-echo { "  global.mosTouchProbeReferencePos=" ^ global.mosTouchProbeReferencePos }
-echo { "===" }
+echo { "=== MOS Touch Probe:" }
+echo { "      global.mosTouchProbeID=" ^ global.mosTouchProbeID }
+echo { "      global.mosTouchProbeRadius=" ^ global.mosTouchProbeRadius }
+echo { "      global.mosTouchProbeDeflection=" ^ global.mosTouchProbeDeflection }
+echo { "      global.mosTouchProbeReferencePos=" ^ global.mosTouchProbeReferencePos }
 
-echo { "MOS Toolsetter:" }
-echo { "  global.mosToolSetterID=" ^ global.mosToolSetterID }
-echo { "  global.mosToolSetterPos=" ^ global.mosToolSetterPos }
-echo { "  global.mosToolSetterActivationPos=" ^ global.mosToolSetterActivationPos }
+echo { "=== MOS Toolsetter:" }
+echo { "      global.mosToolSetterID=" ^ global.mosToolSetterID }
+echo { "      global.mosToolSetterPos=" ^ global.mosToolSetterPos }
+echo { "      global.mosToolSetterActivationPos=" ^ global.mosToolSetterActivationPos }
 
-echo { "MOS Spindle:"}
-echo { "  global.mosSpindleID=" ^ global.mosSpindleID }
-echo { "  global.mosSpindleAccelSeconds=" ^ global.mosSpindleAccelSeconds }
-echo { "  global.mosSpindleDecelSeconds=" ^ global.mosSpindleDecelSeconds }
+echo { "=== MOS Spindle:"}
+echo { "      global.mosSpindleID=" ^ global.mosSpindleID }
+echo { "      global.mosSpindleAccelSeconds=" ^ global.mosSpindleAccelSeconds }
+echo { "      global.mosSpindleDecelSeconds=" ^ global.mosSpindleDecelSeconds }
+
+if { exists(param.D) && param.D == 1 }
+    echo "=== Additional Output from RRF for debugging purposes"
+    M409 K"limits"
+    M409 K"move"
+    M409 K"sensors"
+    M409 K"spindles"
+    M409 K"state"
+    M409 K"tools"
+    echo "==="

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -174,6 +174,10 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
             abort { "MillenniumOS: Operator aborted machine homing!" }
         G28
 
+
+    ; Park centrally to enable the 1-2-3 block installation
+    G27
+
     M291 P{"Please secure your 1-2-3 block or chosen rectangular item onto the table, largest face on top.<br/><b>CAUTION</b>: Please make sure all 4 side surfaces are free of obstructions!"} R"MillenniumOS: Configuration Wizard" S2 T0
     M291 P{"Please enter the exact <b>surface length</b> of the rectangular item along the X axis in mm.<br/><b>NOTE</b>: Along the X axis means the surface facing towards the operator."} R"MillenniumOS: Configuration Wizard" J1 T0 S6 F50.8
     if { result != 0 }

--- a/macro/tool-change/tfree.g
+++ b/macro/tool-change/tfree.g
@@ -13,7 +13,7 @@ G27 Z1
 var tI = { state.currentTool }
 
 ; If probe tool is selected
-if { var.tI == global.mosProbeToolID }
+if { state.currentTool == global.mosProbeToolID }
     if { global.mosFeatureTouchProbe }
         M291 P{"Please remove the touch probe now and stow it safely away from the machine. Click <b>OK</b> when stowed safely."} R{"MillenniumOS: Touch Probe"} S2
     else

--- a/macro/tool-change/tpost.g
+++ b/macro/tool-change/tpost.g
@@ -4,8 +4,7 @@
 ; to probe tool length or reference surface
 ; position if touch probe is installed.
 
-var tI = { state.currentTool }
-if { var.tI < 0 }
+if { state.currentTool < 0 }
     M99
 
 if { !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed }
@@ -14,13 +13,13 @@ if { !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed }
 ; Stop and park the spindle
 G27 Z1
 
-var tD = {(exists(tools[var.tI])) ? tools[var.tI].name : "Unknown Tool" }
+var tD = {(exists(tools[state.currentTool])) ? tools[state.currentTool].name : "Unknown Tool" }
 
 ; If touch probe is current tool, and enabled, and we have not calculated
 ; the toolsetter activation position yet, then run G6511 to probe the
 ; reference surface so we can make this calculation.
 ; Touchprobe tool ID is only set if the touchprobe feature is enabled.
-if { var.tI == global.mosProbeToolID }
+if { state.currentTool == global.mosProbeToolID }
     if { global.mosFeatureTouchProbe }
         ; Check if requested probe ID was detected.
         var touchProbeConnected = { exists(global.mosProbeDetected[global.mosTouchProbeID]) ? global.mosProbeDetected[global.mosTouchProbeID] : false }

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -8,8 +8,7 @@
 ; executing T<n> without any additional parameters
 ; to block tool change macros.
 
-var tI = { state.nextTool }
-if { var.tI < 0 }
+if { state.nextTool < 0 }
     abort {"No tool selected!"}
     M99
 
@@ -21,10 +20,10 @@ if { !move.axes[0].homed || !move.axes[1].homed || !move.axes[2].homed }
 ; Stop and park the spindle
 G27 Z1
 
-var tD = {(exists(tools[var.tI])) ? tools[var.tI].name : "Unknown Tool" }
+var tD = {(exists(tools[state.nextTool])) ? tools[state.nextTool].name : "Unknown Tool" }
 
 ; Check if we're switching to a probe.
-if { var.tI == global.mosProbeToolID }
+if { state.nextTool == global.mosProbeToolID }
     ; If touch probe is enabled, prompt the operator to install
     ; it and check for activation.
     if { global.mosFeatureTouchProbe }
@@ -57,7 +56,7 @@ else
         M291 P{"A tool change is required. You will be asked to insert the correct tool, and then the tool length will be probed using " ^ var.toolLengthProbeMethod} R"MillenniumOS: Tool Change" S2 T0
 
     ; Prompt user to change tool
-    M291 P{"Insert Tool <b>#" ^ var.tI ^ "</b>: " ^ var.tD ^ " and press <b>Continue</b> when ready. <b>Cancel</b> will abort the running job!"} R"MillenniumOS: Tool Change" S4 K{"Continue", "Cancel"}
+    M291 P{"Insert Tool <b>#" ^ state.nextTool ^ "</b>: " ^ var.tD ^ " and press <b>Continue</b> when ready. <b>Cancel</b> will abort the running job!"} R"MillenniumOS: Tool Change" S4 K{"Continue", "Cancel"}
     if { input != 0 }
         echo { "Tool change aborted by operator, aborting job!" }
         M99


### PR DESCRIPTION
It turns out the RRF tool table is lazily allocated. If you define a tool with index 1, then RRF will create a table with 2 entries (0 and 1, with 0 being null). This means it is not simply enough to check that the tool number is within the limits, because the tool entry itself might not exist.

This did not show up in testing because we use the last index in the tool table as the probe tool, and our RRF config was not creating tools in config.g.

It is still good practice to not create tools in config.g as MOS is supposed to manage the tool list, but we should no longer throw errors when trying to add or remove tools using M4000 and M4001 if the tool table has been lazily allocated.

Also update M7600 so it outputs useful object model fields for debugging when called with D1.