### PR TITLE
Compensate for probe deflection in X and Y separately

### DIFF
--- a/macro/machine/M4001.g
+++ b/macro/machine/M4001.g
@@ -25,6 +25,6 @@ if { #tools < param.P || tools[param.P] == null }
 M563 P{param.P} R-1 S"Unknown Tool"
 
 ; Reset tool description in zero-indexed array
-set global.mosToolTable[param.P] = global.mosEmptyTool
+set global.mosToolTable[param.P] = { global.mosEmptyTool }
 
 M7500 S{"Removed tool #" ^ param.P}

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -161,14 +161,14 @@ M400
 ; The tool radius we use here already includes a deflection value
 ; which is deemed to be the same for each X/Y axis.
 ; TODO: Is this a safe assumption?
-M7500 S{"Compensating for tool radius of " ^ global.mosToolTable[state.currentTool][0] ^ "mm."}
+M7500 S{"Compensating for Tool # " ^ state.currentTool ^ " R=" ^ global.mosToolTable[state.currentTool][0] ^ " dX=" ^ global.mosToolTable[state.currentTool][1][0] ^ " dY=" ^ global.mosToolTable[state.currentTool][1][1]}
 
 ; Calculate the magnitude of the direction vector of probe movement
 var mag = { sqrt(pow(global.mosProbeCoordinate[0] - var.sX, 2) + pow(global.mosProbeCoordinate[1] - var.sY, 2)) }
 
 ; Adjust the final position along the direction of movement in X and Y by the tool radius.
-set global.mosProbeCoordinate[0] = { global.mosProbeCoordinate[0] + global.mosToolTable[state.currentTool][0] * ((global.mosProbeCoordinate[0] - var.sX) / var.mag) }
-set global.mosProbeCoordinate[1] = { global.mosProbeCoordinate[1] + global.mosToolTable[state.currentTool][0] * ((global.mosProbeCoordinate[1] - var.sY) / var.mag) }
+set global.mosProbeCoordinate[0] = { global.mosProbeCoordinate[0] + (global.mosToolTable[state.currentTool][0] - global.mosToolTable[state.currentTool][1][0]) * ((global.mosProbeCoordinate[0] - var.sX) / var.mag) }
+set global.mosProbeCoordinate[1] = { global.mosProbeCoordinate[1] + (global.mosToolTable[state.currentTool][0] - global.mosToolTable[state.currentTool][1][1]) * ((global.mosProbeCoordinate[1] - var.sY) / var.mag) }
 
 ; We do not adjust by the tool radius in Z.
 

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -363,12 +363,15 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
 
     M291 P{"Measured block dimensions are <b>X=" ^ global.mosWorkPieceDimensions[0] ^ " Y=" ^ global.mosWorkPieceDimensions[1] ^ "</b>.<br/>Current probe location is over the center of the item."} R"MillenniumOS: Configuration Wizard" S2 T0
 
-    var deflectionX = { var.measuredX - global.mosWorkPieceDimensions[0] }
-    var deflectionY = { var.measuredY - global.mosWorkPieceDimensions[1] }
+    var deflectionX = { (var.measuredX - global.mosWorkPieceDimensions[0])/2 }
+    var deflectionY = { (var.measuredY - global.mosWorkPieceDimensions[1])/2 }
 
-    ; We divide the deflection value by 4, as this gives us the deflection value
-    ; that we would need to apply to each probe point.
-    set var.wizTouchProbeDeflection = { (var.deflectionX + var.deflectionY) / 4 }
+    ; Deflection values are stored separately per axis, as 3d touch probes almost
+    ; always have different deflection values. These are applied during the
+    ; compensation stage of the probe routine (G6512) and are multiplied by
+    ; the direction of movement of the probe to account for the fact that
+    ; probe moves might happen in both X and Y at once.
+    set var.wizTouchProbeDeflection = { var.deflectionX, var.deflectionY }
 
     ; Reset the tool radius back to the existing, possibly-deflected value
     ; as we cannot guarantee that the rest of the configuration wizard will
@@ -376,7 +379,7 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
     ; On completion, the deflection value will be written to file and will be
     ; applied at the next reboot.
 
-    M291 P{"Measured deflection is <b>" ^ var.wizTouchProbeDeflection ^ "mm</b>.<br/>This will be applied to your touch probe on reboot or reload."} R"MillenniumOS: Configuration Wizard" S2 T0
+    M291 P{"Measured deflection is <b>X=" ^ var.wizTouchProbeDeflection[0] ^ " Y=" ^ var.wizTouchProbeDeflection[1] ^ "</b>.<br/>This will be applied to your touch probe on reboot or reload."} R"MillenniumOS: Configuration Wizard" S2 T0
 
     ; Switch away from the wizard touch probe.
     T-1 P0

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -33,7 +33,8 @@ if { global.mosFeatureTouchProbe }
         M99
 
     ; Add a touch probe tool at the last index in the tool table.
-    M4000 S{"Touch Probe"} P{global.mosProbeToolID} R{global.mosTouchProbeRadius - global.mosTouchProbeDeflection}
+    ; Make sure to specify deflection values for compensation.
+    M4000 S{"Touch Probe"} P{global.mosProbeToolID} R{global.mosTouchProbeRadius} X{global.mosTouchProbeDeflection[0]} Y{global.mosTouchProbeDeflection[1]}
 else
     if { !exists(global.mosDatumToolRadius) || global.mosDatumToolRadius == null }
         set global.mosStartupError = { "<b>global.mosDatumToolRadius</b> is not set. Run the configuration wizard to fix this (<b>G8000</b>)." }

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -43,10 +43,8 @@ global mosTouchProbeToolName = "Touch Probe"
 global mosDatumToolName = "Datum Tool"
 
 ; Store additional tool information.
-; Values are: [radius]
-; DO NOT REMOVE THE COMMA, OTHERWISE THIS WILL CREATE A SCALAR
-; RATHER THAN A VECTOR VALUE.
-global mosEmptyTool = { 0.0, }
+; Values are: [radius, {deflection-x, deflection-y}]
+global mosEmptyTool = { 0.0, {0.0, 0.0} }
 global mosToolTable = { vector(limits.tools, global.mosEmptyTool) }
 
 ; Coordinates returned by the most recent probing operation.


### PR DESCRIPTION
Previously, we were averaging the deflection value between X and Y and applying the same deflection compensation to both axes.

This commit splits the deflection value into a vector, first in the configuration wizard, and then in the tool management code (M4000).

Finally, the tool-stored deflection value is applied to the probe location in both X and Y, multiplied by the magnitude of the direction vector of the probe movement - i.e. adjusted based on the direction of the probe move.