### PR TITLE
Add tutorial mode

### DIFF
--- a/macro/movement/G6500.g
+++ b/macro/movement/G6500.g
@@ -9,7 +9,7 @@
 ; to G6500.1 to execute the bore probe cycle.
 
 ; Display description of bore probe if not already displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[2] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[2] }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular bore (hole) in a workpiece by moving downwards into the bore and probing outwards in 3 directions." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will be asked to enter an approximate <b>bore diameter</b> and <b>overtravel distance</b>.<br/>These define how far the probe will move from the centerpoint, without being triggered, before erroring." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will then jog the tool over the approximate center of the bore.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Bore" T0 S2
@@ -62,7 +62,7 @@ else
                 abort { "Probing depth was negative!" }
             else
                 ; Run the bore probe cycle
-                if { !global.mosExpertMode }
+                if { global.mosTutorialMode }
                     M291 P{"Probe will now move downwards " ^ var.probingDepth ^ "mm into the bore and probe towards the edge in 3 directions."} R"MillenniumOS: Probe Bore" J1 T0 S3
                     if { result != 0 }
                         abort { "Bore probe aborted!" }

--- a/macro/movement/G6501.g
+++ b/macro/movement/G6501.g
@@ -9,7 +9,7 @@
 ; passed to the G6501.1 macro to execute the boss probe.
 
 ; Display description of boss probe if not already displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[3] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[3] }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular boss (protruding feature) on a workpiece by probing towards the approximate center of the boss in 3 directions." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will be asked to enter an approximate <b>boss diameter</b> and <b>clearance distance</b>.<br/>These define how far the probe will move away from the centerpoint before probing back inwards." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will then jog the tool over the approximate center of the boss.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Boss" T0 S2
@@ -64,7 +64,7 @@ else
                         abort { "Probing depth was negative!" }
 
                     ; Run the boss probe cycle
-                    if { !global.mosExpertMode }
+                    if { global.mosTutorialMode }
                         M291 P{"Probe will now move outwards by " ^ {(var.bossDiameter/2) + var.clearance} ^ "mm and then downwards " ^ var.probingDepth ^ "mm, before probing towards the edge in 3 directions."} R"MillenniumOS: Probe Boss" T0 S3
                         if { result != 0 }
                             abort { "Boss probe aborted!" }

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -10,7 +10,7 @@
 ; to the underlying G6503.1 macro to execute the probe cycle.
 
 ; Display description of rectangle block probe if not already displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[5] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[5] }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a rectangular block (protruding feature) on a workpiece by probing towards the block surfaces from all 4 directions." R"MillenniumOS: Probe Rect. Block " T0 S2
     M291 P"You will be asked to enter an approximate <b>width</b> and <b>height</b> of the block, and a <b>clearance distance</b>." R"MillenniumOS: Probe Rect. Block" T0 S2
     M291 P"These define how far the probe will move away from the center point before moving downwards and probing back towards the relevant surfaces." R"MillenniumOS: Probe Rect. Block" T0 S2
@@ -78,7 +78,7 @@ else
                             abort { "Probing depth was negative!" }
 
                         ; Run the block probe cycle
-                        if { !global.mosExpertMode }
+                        if { global.mosTutorialMode }
                             M291 P{"Probe will now move outside each surface and down by " ^ var.probingDepth ^ "mm, before probing towards the center."} R"MillenniumOS: Probe Rect. Block" T0 S3
                             if { result != 0 }
                                 abort { "Rectangle block probe aborted!" }

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -17,7 +17,7 @@
 ; the probe cycle.
 
 ; Display description of rectangle block probe if not already displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[10] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[10] }
     M291 P"This probe cycle finds the X and Y co-ordinates of the corner of a rectangular workpiece by probing twice each along the 2 edges that form the corner." R"MillenniumOS: Probe Outside Corner " T0 S2
     M291 P"You will be asked to enter approximate <b>surface lengths</b> for the surfaces forming the corner, a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Outside Corner" T0 S2
@@ -91,7 +91,7 @@ else
                                 abort { "Probing depth must not be negative!" }
 
                             ; Run the block probe cycle
-                            if { !global.mosExpertMode }
+                            if { global.mosTutorialMode }
                                 var cN = { global.mosOutsideCornerNames[var.corner] }
                                 M291 P{"Probe will now move outside the <b>" ^ var.cN ^ "</b> corner and down by " ^ var.probingDepth ^ "mm, before probing 2 points " ^ var.clearance ^ "mm from each end of the surfaces." } R"MillenniumOS: Probe Outside Corner" T0 S3
                                 if { result != 0 }

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -11,7 +11,7 @@
 var zProbeI = { #global.mosSurfaceLocationNames - 1 }
 
 ; Display description of surface probe if not displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[4] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[4] }
     M291 P"This operation finds the co-ordinate of a surface on a single axis. It is usually used to find the top surface of a workpiece but can be used to find X or Y positions as well." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"<b>CAUTION</b>: This operation will only return accurate results if the surface you are probing is perpendicular to the axis you are probing in." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"You will jog the tool or touch probe to your chosen starting position. Your starting position should be outside and above X or Y surfaces, or directly above the top surface." R"MillenniumOS: Probe Surface" T0 S2
@@ -71,7 +71,7 @@ else
             if { var.probeDist < 0 }
                 abort { "Probe distance was negative!" }
 
-            if { !global.mosExpertMode }
+            if { global.mosTutorialMode}
                 if { !var.isZProbe }
                     M291 P{"Probe will now move down <b>" ^ var.probeDepth ^ "</b> mm and probe towards the <b>" ^ global.mosSurfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S3
                     if { result != 0 }

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -18,7 +18,7 @@
 ; the probe cycle.
 
 ; Display description of vise corner probe if not already displayed this session
-if { !global.mosExpertMode && !global.mosDescDisplayed[11] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[11] }
     M291 P"This probe cycle finds the X, Y and Z co-ordinates of the corner of a workpiece by probing the top surface and twice each along the 2 edges that form the corner." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"You will be asked to enter approximate <b>surface lengths</b> for the surfaces forming the corner, a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Vise Corner" T0 S2
@@ -91,7 +91,7 @@ else
                                 abort { "Probing depth must not be negative!" }
 
                             ; Run the block probe cycle
-                            if { !global.mosExpertMode }
+                            if { global.mosTutorialMode }
                                 var cN = { global.mosOutsideCornerNames[var.corner] }
                                 M291 P{"We will now probe the top surface, then move outside the <b>" ^ var.cN ^ "</b> corner and down " ^ var.probeDepth ^ "mm, then probe 2 points " ^ var.clearance ^ "mm from each end of the corner surfaces." } R"MillenniumOS: Probe Vise Corner" T0 S3
                                 if { result != 0 }

--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -22,7 +22,7 @@ G27 Z1
 ; on a work offset.
 var workOffset = null
 
-if { !global.mosExpertMode && !global.mosDescDisplayed[0] }
+if { global.mosTutorialMode && !global.mosDescDisplayed[0] }
     M291 P{"Before executing cutting operations, it is necessary to identify where the workpiece for a part is. We will do this by probing and setting a work co-ordinate system (WCS) origin point."} R"MillenniumOS: Probe Workpiece" T0 S2
     M291 P{"The origin of a WCS is the reference point for subsequent cutting operations, and must match the chosen reference point in your CAM software."} R"MillenniumOS: Probe Workpiece" T0 S2
     M291 P{"You will need to select an appropriate probe cycle type (or types!) based on the shape of your workpiece."} R"MillenniumOS: Probe Workpiece" T0 S2
@@ -52,12 +52,12 @@ else
     set var.workOffset = { param.W }
 
 ; Warn about null work offset
-if { var.workOffset == null && !global.mosExpertMode && !global.mosDescDisplayed[1] }
+if { var.workOffset == null && global.mosTutorialMode && !global.mosDescDisplayed[1] }
     M291 P{"Probing can still run without a WCS origin being set. The output of the probing cycle will be available in the global variables specific to the probe cycle."} R"MillenniumOS: Probe Workpiece" T0 S2
     set global.mosDescDisplayed[1]=true
 
 ; If WCS is set via parameter, warn about setting WCS origin
-if { exists(param.W) && !global.mosExpertMode }
+if { exists(param.W) && global.mosTutorialMode }
     M291 P{"Probing will set the origin of WCS " ^ var.workOffset ^ " (" ^ global.mosWorkOffsetCodes[var.workOffset] ^ ") to the probed location."} R"MillenniumOS: Probe Workpiece" T0 S3
     if { result != 0 }
         abort {"Operator cancelled probe cycle, please set WCS origin manually or restart probing with <b>G6600</b>"}
@@ -71,8 +71,8 @@ if { var.workOffset != null }
     var pdY = { move.axes[1].workplaceOffsets[var.workOffset-1] }
     var pdZ = { move.axes[2].workplaceOffsets[var.workOffset-1] }
 
-    ; If not expert mode, show operator the WCS origin if any axes are set.
-    if { !global.mosExpertMode && (var.pdX != 0 || var.pdY != 0 || var.pdZ != 0) }
+    ; If tutorial mode, show operator the WCS origin if any axes are set.
+    if { global.mosTutorialMode && (var.pdX != 0 || var.pdY != 0 || var.pdZ != 0) }
         M291 P{"WCS " ^ var.workOffset ^ " (" ^ var.workOffsetName ^ ") has origin:<br/>X=" ^ var.pdX ^ " Y=" ^ var.pdY ^ " Z=" ^ var.pdZ} R"MillenniumOS: Probe Workpiece" T0 S2
 
     ; If work offset origin is already set

--- a/macro/private/display-startup-messages.g
+++ b/macro/private/display-startup-messages.g
@@ -20,5 +20,4 @@ if { !global.mosStartupMsgsDisplayed }
             M291 P{ var.startupError } R"MillenniumOS: Startup Error" S2 T10
             M99
     else
-        if { !global.mosExpertMode }
-            echo { "MillenniumOS: Loaded " ^ global.mosVersion }
+        echo { "MillenniumOS: Loaded " ^ global.mosVersion }

--- a/macro/public/3. Config/Settings/Toggle Daemon Tasks.g
+++ b/macro/public/3. Config/Settings/Toggle Daemon Tasks.g
@@ -1,8 +1,6 @@
 ; Toggle Daemon Tasks.g
 
-; Toggles global.mosDaemonEnable so that daemon tasks
-; can be controlled via DWC.
-if { ! global.mosExpertMode }
+if { global.mosTutorialMode }
     M291 R"MillenniumOS: Toggle Daemon Tasks" P{ (global.mosDaemonEnable  ? "Disable" : "Enable" ) ^ " Daemon tasks?" } S3
     if result == -1
         M99

--- a/macro/public/3. Config/Settings/Toggle Debug Mode.g
+++ b/macro/public/3. Config/Settings/Toggle Debug Mode.g
@@ -1,7 +1,5 @@
 ; Toggle Debug Mode.g
 
-; Toggles global.mosDaemonEnable so that daemon tasks
-; can be controlled via DWC.
 if { ! global.mosDebug }
     M291 R"MillenniumOS: Toggle Debug Mode" P"Enable Debug Mode? This will produce very verbose output to the console and may make it hard to find non-debug messages!" S3
     if { result == -1 }

--- a/macro/public/3. Config/Settings/Toggle Expert Mode.g
+++ b/macro/public/3. Config/Settings/Toggle Expert Mode.g
@@ -1,8 +1,6 @@
 ; Toggle Expert Mode.g
 
-; Toggles global.mosDaemonEnable so that daemon tasks
-; can be controlled via DWC.
-if { ! global.mosExpertMode }
+if { global.mosTutorialMode }
     M291 R"MillenniumOS: Toggle Expert Mode" P"Enable Expert Mode? You will no longer be prompted to confirm potentially dangerous actions, and will not see probing descriptions before they are executed!" S3
     if { result == -1 }
         M99

--- a/macro/public/3. Config/Settings/Toggle Toolsetter.g
+++ b/macro/public/3. Config/Settings/Toggle Toolsetter.g
@@ -1,7 +1,5 @@
 ; Toggle Toolsetter.g
 
-; Toggles global.mosDaemonEnable so that daemon tasks
-; can be controlled via DWC.
 if { global.mosFeatureToolSetter }
     M291 R"MillenniumOS: Toggle Toolsetter" P"Disable Toolsetter? You will have to compensate for tool length manually." S3
     if { result == -1 }

--- a/macro/public/3. Config/Settings/Toggle Touch Probe.g
+++ b/macro/public/3. Config/Settings/Toggle Touch Probe.g
@@ -1,14 +1,12 @@
 ; Toggle Touch Probe.g
 
-; Toggles global.mosDaemonEnable so that daemon tasks
-; can be controlled via DWC.
 if { global.mosFeatureTouchProbe }
     M291 R"MillenniumOS: Toggle Touch Probe" P"Disable Touch Probe? This will enable guided manual workpiece probing." S3
     if { result == -1 }
         M99
 
 ; These 3 values are required for touch probe use.
-if { global.mosTouchProbeID == null || global.mosTouchProbeReferencePos == null || global.mosTouchProbeRadius == null  }
+if { global.mosTouchProbeID == null || global.mosTouchProbeReferencePos == null || global.mosTouchProbeRadius == null || global.mosTouchProbeDeflection == null }
     M291 R"MillenniumOS: Toggle Touch Probe" P"Touch Probe has not been configured. Please configure the touch probe using the Configuration Wizard first." S2
     M99
 
@@ -17,7 +15,7 @@ set global.mosFeatureTouchProbe = {!global.mosFeatureTouchProbe}
 ; Switch probe tool name and configuration when toggling touch probe
 if { global.mosFeatureTouchProbe }
     M4001 P{global.mosProbeToolID}
-    M4000 P{global.mosProbeToolID} S{global.mosTouchProbeToolName} R{global.mosTouchProbeRadius - global.mosTouchProbeDeflection}
+    M4000 P{global.mosProbeToolID} S{global.mosTouchProbeToolName} R{global.mosTouchProbeRadius}
 else
     M4001 P{global.mosProbeToolID}
     M4000 P{global.mosProbeToolID} S{global.mosDatumToolName} R{global.mosDatumToolRadius}

--- a/macro/public/3. Config/Settings/Toggle Tutorial Mode.g
+++ b/macro/public/3. Config/Settings/Toggle Tutorial Mode.g
@@ -1,0 +1,11 @@
+; Toggle Tutorial Mode.g
+
+; Toggles global.mosTutorialMode.
+if { !global.mosTutorialMode }
+    M291 R"MillenniumOS: Toggle Tutorial Mode" P"Enable <b>Tutorial Mode</b>?<br/>Tutorial Mode enables probing cycle guides and additional confirmation points during operations." S3
+    if { result == -1 }
+        M99
+
+set global.mosTutorialMode = {!global.mosTutorialMode}
+
+echo {"MillenniumOS: Tutorial Mode " ^ (global.mosTutorialMode ? "Enabled" : "Disabled")}

--- a/macro/public/3. Config/Settings/Toggle VSSC.g
+++ b/macro/public/3. Config/Settings/Toggle VSSC.g
@@ -2,7 +2,7 @@
 
 ; Toggles global.mosVsscOverrideEnabled so that VSSC behaviour can be overridden
 ; by the operator on the fly.
-if { ! global.mosExpertMode }
+if { global.mosTutorialMode }
     M291 R"MillenniumOS: Toggle VSSC" P{ (global.mosVsscOverrideEnabled  ? "Disable" : "Enable" ) ^ " Variable Spindle Speed Control?" } S3
     if { result == -1 }
         M99

--- a/macro/tool-change/tpost.g
+++ b/macro/tool-change/tpost.g
@@ -29,7 +29,8 @@ if { state.currentTool == global.mosProbeToolID }
             abort {"Did not detect a " ^ var.tD ^ " with ID " ^ global.mosTouchProbeID ^ "! Please check your " ^ var.tD ^ " and run T" ^ global.mosProbeToolID ^ " again to verify it is connected."}
             M99
         else
-            M291 P{"<b>Touch Probe Detected</b>.<br/>We will now probe the reference surface. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
+            if { !global.mosExpertMode }
+                M291 P{"<b>Touch Probe Detected</b>.<br/>We will now probe the reference surface. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
             G6511
             if { global.mosToolSetterActivationPos == null }
                 abort { "Touch probe reference surface probing failed." }

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -51,7 +51,7 @@ else
     ; All other tools cannot be detected so we just have to
     ; trust the operator did the right thing given the
     ; information :)
-    if { !global.mosExpertMode }
+    if { global.mosTutorialMode }
         var toolLengthProbeMethod = { (global.featureToolSetter) ? "your Toolsetter." : "a Guided Manual probing procedure." }
         M291 P{"A tool change is required. You will be asked to insert the correct tool, and then the tool length will be probed using " ^ var.toolLengthProbeMethod} R"MillenniumOS: Tool Change" S2 T0
 

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -66,4 +66,4 @@ if { !global.mosFeatureSpindleFeedback }
 set global.mosLoaded = true
 
 if { global.mosExpertMode }
-    echo { "WARNING: Expert mode is enabled! You will not see any modals describing what MillenniumOS is about to do, and will not be asked to confirm any actions!" }
+    echo { "WARNING: Expert mode is enabled! You will not be asked to confirm any actions. Be careful!" }

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -8,9 +8,15 @@ global mosFeatureTouchProbe=false
 global mosFeatureSpindleFeedback=false
 global mosFeatureVSSC=true
 
-; Expert mode skips descriptor steps during tool changes and probing operations. It does not skip
-; safety checks, but assumes the operator knows how the probing operation they are performing works.
+; Expert mode skips certain operator confirmation checks during tool changes and probing operations.
+; Anything deemed to be safety critical is still executed, but the operator will not be prompted to
+; confirm completed tool changes, or starting probe operations.
 global mosExpertMode=false
+
+; Tutorial mode explains in detail the operation of a probe or tool change operation prior to the
+; actual operation being executed. This is useful for those new to machining who might need a little
+; more guidance before feeling happy pushing 'the button'.
+global mosTutorialMode=true
 
 ; Debut mode emits additional debug information during usage.
 global mosDebug=false


### PR DESCRIPTION
Tutorial mode allows probing and configuration tutorials to be enabled or disabled during the configuration wizard. We separate some usages of expert mode into tutorial mode instead. Expert mode now only applies to certain actions that _could_ have safety implications if an operator is unfamiliar with the way a probing or other cycle works.

Tutorial mode is _never_ used in situations with potential safety implications, disabling it just removes some descriptions of how a cycle will be executed.