### PR TITLE
Fix protected move back-off distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MillenniumOS (MOS) - An "Operations System" for RepRapFirmware.
+
 Cheap and easy manual and automatic work-piece probing, toolchanges and toolsetting and more!
 
 This is an "operations system" rather than an "operating system" in the traditional sense.
@@ -6,6 +7,7 @@ This is an "operations system" rather than an "operating system" in the traditio
 We build _on top of_ RepRapFirmware, providing operators of the Millennium Machines Milo V1.5 with a new-machinist-friendly workflow for work piece and tool probing, and safe, effective tool changes.
 
 ## Features
+
   - Canned probing cycles usable directly from gcode or via Duet Web Control as named macros.
   - Fallbacks to guided manual probing when touch probe and / or toolsetter is not available.
   - Safety checks at every step to instill confidence in novice machinists.
@@ -13,19 +15,22 @@ We build _on top of_ RepRapFirmware, providing operators of the Millennium Machi
   - Compatible with Millennium Machines Milo GCode Dialect.
 
 ## Usage
+
   - Configure your toolsetter and optionally, touch probe, in RRF. Please see [here](#rrf-config) for instructions.
   - Download the ZIP file of a release.
-  - Extract the ZIP file onto the root of your SD card, or upload it to DWC.
-  - Add `M98 P"mos.g"` to the bottom of your `config.g` file.
+  - Extract the ZIP file onto the root of your SD card, or upload the ZIP directly into Duet Web Control. If uploading, you can use the **"Upload System Files"** button in the **Files** -> **System** window, and you do not need to extract the ZIP file first.
+  - Add `M98 P"mos.g"` to the bottom of your `config.g` file. You can edit this via the **Files** -> **System** window.
   - Restart RRF (`M999`)
   - Follow the configuration wizard in Duet Web Control that will guide you through the necessary configuration settings.
   - Install one of the post-processors from [here](./post-processors/) into your CAM tool of choice.
 
 ## Notes
+
   - You _must_ be using RRF `v3.5.0-rc.1` or above. MOS uses many 'meta gcode' features that do not exist in earlier versions.
   - MOS includes its own `daemon.g` file to implement repetitive tasks, such as VSSC. If you want to implement your own repetitive tasks, you should create a `user-daemon.g` file in the `/sys` directory, which MillenniumOS will run during its' own daemon loop. Disabling the MOS daemon tasks will also disable any `user-daemon.g` tasks. Do not use any long-running loops inside `user-daemon.g` as this will interfere with MOS's own daemon behaviour.
 
 ## RRF Config
+
 You need a working RRF config with all of your machine axes moving in the right direction before you start.
 
 If you can't home your machine, make that work first - following the MillenniumOS configuration wizard will be impossible without a machine that moves correctly.
@@ -59,9 +64,11 @@ M558 K1 P8 C"xstopmax" H10 A10 S0.01 T1200 F300:60
 ```
 
 ### Tool Definition
+
 You will also want to remove any manual tool definitions from your configuration, as MillenniumOS manages tools through the `M4000` and `M4001` custom M-codes - remove any lines in your `config.g` that use the `M563` command, and also any lines which refer to tools which would have been created by these commands (e.g. `G10 P<toolnumber>`).
 
 ### Touch Probe Type Configuration
+
 Some touch probes may not filter their outputs, which means they can be subject to bouncing. This is where, when the switch or detection mechanism inside the touch probe changes state, it flaps between the two states before settling into its' final position. This can cause issues in MillenniumOS with protected moves, as we stop moving when the probe is activated or deactivated but by the time we check the probe status, it might have flipped.
 
 The solution for this is to define the touch probe as ID _Zero_ and the probe type as 5 (`M558 K0 P5 C"probe"...`), as in the above example configuration line. This enables filtering in RRF which debounces the probe input. The downside of this is that the probe may respond more slowly, but this is not necessarily a problem as the delay is likely to be accounted for in the deflection values calculated for X and Y. It is also not possible to define more than one probe as type 5, so if you already have a probe that requires type 5 that is _not_ your touch probe then this may be an issue.
@@ -69,6 +76,7 @@ The solution for this is to define the touch probe as ID _Zero_ and the probe ty
 Your touch probe may not need filtering, and you can test this by moving it to a different probe ID (2, for example) and changing the type to 8 like the toolsetter definition.
 
 ## Warnings and Known Issues
+
 Due to some issues with RRF as it currently stands, there are a small number of situations where you can shoot yourself in the foot when running MillenniumOS macros outside of a print file. These are:
 
  - Clicking Cancel on a messagebox to abort a probing routine may trigger undesired behaviour when running a probe **outside** of a print file. This is because clicking cancel on a message box, if outside of a print, simply returns from the macro that created the box. There is no way to easily detect this from any calling macros so we could end up running moves that were unexpected. This is something that ideally will need to be fixed by the RRF devs and is documented [here](https://forum.duet3d.com/topic/34945/meta-gcode-result-variable-inconsistent-with-docs?_=1707734672834). When clicking cancel from _within_ a print, the whole print is aborted from that point so this behaviour should not be an issue when executing actual CAM code produced by our post-processor.
@@ -80,12 +88,15 @@ Due to some issues with RRF as it currently stands, there are a small number of 
  - If the touch probe is activated during a protected move, then due to how this is implemented in RRF it is _possible_ that the speeds of the probe were not reset correctly. Subsequent probes will run at the same speed which might be very slow, or very fast (if the interrupted move was a travel move). You should be aware of this when restarting from a collision during a protected move. We are currently looking for options as to how to improve this behaviour, but it may involve underlying changes to RRF to allow this.
 
 ## Bugs, Issues, Support
+
 If you find any bugs or issues, please create an issue on this repository. Best-effort support is available via our [Discord](https://discord.gg/ya4UUj7ax2).
 
 ### Troubleshooting
+
 To help us work out any issues, please run `M7600 D1` and paste the whole output into any issue you create, or attach with any help request in Discord. This output includes the value of MOS specific variables and also the contents of the RRF object model - specifically the limits, move, sensors, spindles, state and tool keys which are essential for debugging MillenniumOS functionality (or lack thereof).
 
 ## Liability
+
 You are fully responsible for running the code contained in this library on your own machine. It has been tested on a number of different machines by different people, and is written from a safety-first perspective, but it is a fool who thinks that they can write software without bugs, and it is a (somewhat lesser) fool to _use_ that software and not expect occasional shenanigans. These shenanigans might cos you money in the best case, and blood in the worst - and by using this software you agree that we are not liable for any losses that might occur during your use of the software.
 
 It is up to you, and only you, to take the relevant precautions when using MillenniumOS - run your tool paths without a workpiece installed and spindle disabled, test the probing routines with soft(er) items (e.g. a roll of tape for bore probe, a cardboard box for block or corner probes), and stay away from the machine when it is moving!
@@ -97,9 +108,11 @@ Remember that this is designed for machines that can really hurt you if you're n
 ## In Depth
 
 ### Implemented G- and M- codes
+
 See [GCODE.md](GCODE.md) for a description of all MOS implemented G- and M- codes.
 
 ### Post-processor
+
 MillenniumOS is designed to work with a specific gcode dialect, designed for the Millennium Machines Milo. It does not support any other gcode dialects.
 
 The following is an example gcode style that MOS is designed to understand:

--- a/dist/release.sh
+++ b/dist/release.sh
@@ -2,6 +2,7 @@
 WD="${PWD}"
 TMP_DIR=$(mktemp -d -t mos-release-XXXXX)
 ZIP_NAME="${1:-mos-release}.zip"
+ZIP_PATH="${WD}/dist/${ZIP_NAME}"
 SYNC_CMD="rsync -a --exclude=README.md"
 COMMIT_ID=$(git describe --tags --exclude "release-*" --always --dirty)
 
@@ -21,7 +22,7 @@ ${SYNC_CMD} post-processors/**/* ${TMP_DIR}/posts/
 
 find ${TMP_DIR}
 
-[[ -f ${ZIP_NAME} ]] && rm ${ZIP_NAME}
+[[ -f ${ZIP_PATH} ]] && rm ${ZIP_PATH}
 
 cd "${TMP_DIR}"
 mv sys/daemon.g sys/daemon.install

--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -15,10 +15,6 @@ if { !exists(param.P) || !exists(param.R) || !exists(param.S) }
 if { param.P >= limits.tools || param.P < 0 }
     abort { "Tool index must be between 0 and " ^ limits.tools-1 ^ "!" }
 
-; Dont allow tools to be overwritten, they must be actively deleted first.
-if { param.P < #tools && tools[param.P].spindle != -1 }
-    abort { "Tool #" ^ param.P ^ " is already defined on spindle " ^ tools[param.P].spindle ^ "!" }
-
 ; Define RRF tool against spindle.
 ; Allow spindle ID to be overridden where necessary using I parameter.
 ; This is mainly used during the configuration wizard.

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -90,6 +90,7 @@ var wizToolSetterPos = { (exists(global.mosToolSetterPos) && global.mosToolSette
 var wizTouchProbeID = { (exists(global.mosTouchProbeID) && global.mosTouchProbeID != null && !var.wizReset && !var.wizTouchProbeReset) ? global.mosTouchProbeID : null }
 var wizTouchProbeRadius = { (exists(global.mosTouchProbeRadius) && global.mosTouchProbeRadius != null && !var.wizReset && !var.wizTouchProbeReset) ? global.mosTouchProbeRadius : null }
 var wizTouchProbeDeflection = { (exists(global.mosTouchProbeDeflection) && global.mosTouchProbeDeflection != null && !var.wizReset && !var.wizTouchProbeReset) ? global.mosTouchProbeDeflection : null }
+var wizProtectedMoveBackOff = { (exists(global.mosProtectedMoveBackOff) && global.mosProtectedMoveBackOff != null && !var.wizReset && !var.wizTouchProbeReset && !var.wizToolSetterReset) ? global.mosProtectedMoveBackOff : null }
 
 ; Touch Probe Ref Surface is reconfigured if toolsetter _or_
 ; touch probe are reconfigured.
@@ -446,6 +447,11 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
     ; Remove the temporary probe tool.
     M4001 P{global.mosProbeToolID}
 
+if { (var.wizFeatureToolSetter || var.wizFeatureTouchProbe) && var.wizProtectedMoveBackOff == null }
+    if { var.wizTutorialMode }
+        M291 P{"We now need to enter a <b>back-off distance</b> for protected moves.<br/>This is the distance we will initially move when a touch probe or toolsetter is activated, to deactivate it."} R"MillenniumOS: Configuration Wizard" S2 T0
+    M291 P{"Please enter the back-off distance for protected moves."} R"MillenniumOS: Configuration Wizard" S6 L0.1 H5 F0.5
+    set var.wizProtectedMoveBackOff = { input }
 
 ; Overwrite the mos-user-vars.g file with the first line
 echo >{var.wizUserVarsFile} "; mos-user-vars.g: MillenniumOS User Variables"
@@ -509,6 +515,10 @@ if { var.wizTouchProbeDeflection != null }
 if { var.wizDatumToolRadius != null }
     echo >>{var.wizUserVarsFile} "; Datum Tool Radius"
     echo >>{var.wizUserVarsFile} {"set global.mosDatumToolRadius = " ^ var.wizDatumToolRadius }
+
+if { var.wizProtectedMoveBackOff != null }
+    echo >>{var.wizUserVarsFile} "; Protected Move Back-Off"
+    echo >>{var.wizUserVarsFile} {"set global.mosProtectedMoveBackOff = " ^ var.wizProtectedMoveBackOff }
 
 if { global.mosLoaded }
     M291 P{"Configuration wizard complete. Your configuration has been saved to " ^ var.wizUserVarsFile ^ ". Press OK to reload!"} R"MillenniumOS: Configuration Wizard" S2 T0

--- a/macro/private/run-vssc.g
+++ b/macro/private/run-vssc.g
@@ -44,7 +44,7 @@ if { var.curSpindleSpeed == 0 }
 ; stored base RPM.
 var lowerLimit = global.mosVsscPreviousAdjustmentRPM - global.mosVsscVariance
 var upperLimit = global.mosVsscPreviousAdjustmentRPM + global.mosVsscVariance
-var maxRPM = spindle[global.mosSpindleID].max
+var maxRPM = spindles[global.mosSpindleID].max
 if { var.upperLimit > var.maxRPM }
     set var.upperLimit = var.maxRPM
     set var.lowerLimit = { var.maxRPM - (2*global.mosVsscVariance) }

--- a/macro/tool-change/tpost.g
+++ b/macro/tool-change/tpost.g
@@ -31,7 +31,9 @@ if { state.currentTool == global.mosProbeToolID }
         else
             if { !global.mosExpertMode }
                 M291 P{"<b>Touch Probe Detected</b>.<br/>We will now probe the reference surface. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
-            G6511
+            ; Call reference surface probe in non-standalone mode to
+            ; run the actual probe.
+            G6511 S0
             if { global.mosToolSetterActivationPos == null }
                 abort { "Touch probe reference surface probing failed." }
                 M99

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -52,7 +52,7 @@ else
     ; trust the operator did the right thing given the
     ; information :)
     if { global.mosTutorialMode }
-        var toolLengthProbeMethod = { (global.featureToolSetter) ? "your Toolsetter." : "a Guided Manual probing procedure." }
+        var toolLengthProbeMethod = { (global.mosFeatureToolSetter) ? "your Toolsetter." : "a Guided Manual probing procedure." }
         M291 P{"A tool change is required. You will be asked to insert the correct tool, and then the tool length will be probed using " ^ var.toolLengthProbeMethod} R"MillenniumOS: Tool Change" S2 T0
 
     ; Prompt user to change tool

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -255,6 +255,7 @@ var G = {
   PROBE_RECTANGLE_POCKET: 6502.1,
   PROBE_RECTANGLE_BLOCK: 6503.1,
   PROBE_SINGLE_SURFACE: 6510.1,
+  PROBE_REFERENCE_SURFACE: 6511,
   PROBE_VISE_CORNER: 6520.1,
 };
 
@@ -311,6 +312,7 @@ var gCodesF = createModalGroup(
         G.PROBE_RECTANGLE_POCKET,
         G.PROBE_RECTANGLE_BLOCK,
         G.PROBE_SINGLE_SURFACE,
+        G.PROBE_REFERENCE_SURFACE,
         G.PROBE_VISE_CORNER,
       ] // Probe codes
   ],
@@ -432,6 +434,12 @@ function onOpen() {
       writeBlock(gCodesF.format(G.HOME));
       writeln("");
     }
+
+    // We trigger a reference surface probe here. If the surface
+    // is already probed, this is a no-op.
+    writeComment("Probe reference surface if necessary");
+    writeBlock(gCodesF.format(G.PROBE_REFERENCE_SURFACE));
+    writeln("");
 
     writeComment("WCS Probing Mode: {mode}".supplant({mode: getProperty("jobWCSProbeMode")}));
     if(getProperty("jobWCSProbeMode") === wcsProbeMode.ATSTART) {

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -53,6 +53,10 @@ if { global.mosFeatureToolSetter }
         M99
 
 
+if { (global.mosFeatureToolSetter || global.mosFeatureTouchProbe) && global.mosProtectedMoveBackOff == null }
+    set global.mosStartupError = { "<b>global.mosProtectedMoveBackOff</b> is not set. Run the configuration wizard to fix this (<b>G8000</b>)." }
+    M99
+
 if { !global.mosFeatureSpindleFeedback }
     if { !exists(global.mosSpindleAccelSeconds) || global.mosSpindleAccelSeconds == null }
         set global.mosStartupError = { "<b>global.mosSpindleAccelSeconds</b> is not set. Run the configuration wizard to fix this (<b>G8000</b>)." }

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -171,6 +171,8 @@ global mosTouchProbeDeflection = null
 global mosTouchProbeReferencePos = null
 global mosDatumToolRadius = null
 
+global mosProtectedMoveBackOff = null
+
 global mosManualProbeSpeed = { 1200, 300, 60 }
 global mosManualProbeBackoff=5
 


### PR DESCRIPTION
Previously, the back-off distance (when probe is activated and we need to back off slightly so we can move the rest of the way looking for probe activation) was based on the tool radius, but this is open to issues with very large or very small tools. Instead, we add a new setting, `global.mosProtectedMoveBackoff` which is a distance in mm to back off before trying a protected move. This setting is configurable in the configuration wizard.

We also fix reference surface probes.

Reference surface probes are needed if a touch probe has been used to set workpiece origins. Even if we do not output probe cycle commands from the post (because the origin is already probed), we _must_ make sure that the surface position has been probed otherwise tool changes will generate an error.

We now make sure `G6511` can be called from a gcode file. It will be a no-op if the surface is already probed or the toolsetter or touch probe feature is disabled. It will switch to the touch probe if necessary.

It is run before any generated probe cycles so any initial WCS probe will not require disconnecting and reinserting the touch probe.

We make sure `G6511` is outputted by the post-processor even in WCS probe mode NONE.

We also update the README to better explain how to install MillenniumOS using the Duet Web Console.

Finally, there was an issue with VSSC and an incorrectly named variable which is now fixed.