### PR TITLE
Remove nesting in all probe macros

### DIFF
--- a/macro/movement/G6500.g
+++ b/macro/movement/G6500.g
@@ -39,39 +39,39 @@ if { global.mosPTID != state.currentTool }
 M291 P"Please enter approximate bore diameter in mm." R"MillenniumOS: Probe Bore" J1 T0 S6 F{(global.mosWPRad != null) ? global.mosWPRad*2 : 0}
 if { result != 0 }
     abort { "Bore probe aborted!" }
-else
-    var boreDiameter = { input }
 
-    if { var.boreDiameter < 1 }
-        abort { "Bore diameter too low!" }
+var boreDiameter = { input }
+
+if { var.boreDiameter < 1 }
+    abort { "Bore diameter too low!" }
 
 
-    ; Prompt for overtravel distance
-    M291 P"Please enter overtravel distance in mm." R"MillenniumOS: Probe Bore" J1 T0 S6 F{global.mosOT}
+; Prompt for overtravel distance
+M291 P"Please enter overtravel distance in mm." R"MillenniumOS: Probe Bore" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Bore probe aborted!" }
+
+var overTravel = { input }
+if { var.overTravel < 0.1 }
+    abort { "Overtravel distance too low!" }
+
+M291 P"Please jog the probe <b>OVER</b> the center of the bore and press <b>OK</b>." R"MillenniumOS: Probe Bore" X1 Y1 Z1 J1 T0 S3
+if { result != 0 }
+    abort { "Bore probe aborted!" }
+
+M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing outwards." R"MillenniumOS: Probe Bore" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Bore probe aborted!" }
+
+var probingDepth = { input }
+
+if { var.probingDepth < 0 }
+    abort { "Probing depth was negative!" }
+
+; Run the bore probe cycle
+if { global.mosTM }
+    M291 P{"Probe will now move downwards " ^ var.probingDepth ^ "mm into the bore and probe towards the edge in 3 directions."} R"MillenniumOS: Probe Bore" J1 T0 S3
     if { result != 0 }
         abort { "Bore probe aborted!" }
-    else
-        var overTravel = { input }
-        if { var.overTravel < 0.1 }
-            abort { "Overtravel distance too low!" }
 
-        M291 P"Please jog the probe <b>OVER</b> the center of the bore and press <b>OK</b>." R"MillenniumOS: Probe Bore" X1 Y1 Z1 J1 T0 S3
-        if { result != 0 }
-            abort { "Bore probe aborted!" }
-        else
-            M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing outwards." R"MillenniumOS: Probe Bore" J1 T0 S6 F{global.mosOT}
-            if { result != 0 }
-                abort { "Bore probe aborted!" }
-
-            var probingDepth = { input }
-
-            if { var.probingDepth < 0 }
-                abort { "Probing depth was negative!" }
-            else
-                ; Run the bore probe cycle
-                if { global.mosTM }
-                    M291 P{"Probe will now move downwards " ^ var.probingDepth ^ "mm into the bore and probe towards the edge in 3 directions."} R"MillenniumOS: Probe Bore" J1 T0 S3
-                    if { result != 0 }
-                        abort { "Bore probe aborted!" }
-
-                G6500.1 W{exists(param.W)? param.W : null} H{var.boreDiameter} O{var.overTravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6500.1 W{exists(param.W)? param.W : null} H{var.boreDiameter} O{var.overTravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6501.g
+++ b/macro/movement/G6501.g
@@ -33,47 +33,47 @@ if { global.mosPTID != state.currentTool }
 M291 P"Please enter approximate boss diameter in mm." R"MillenniumOS: Probe Boss" J1 T0 S6 F{(global.mosWPRad != null) ? global.mosWPRad*2 : 0}
 if { result != 0 }
     abort { "Boss probe aborted!" }
-else
-    var bossDiameter = { input }
 
-    if { var.bossDiameter < 1 }
-        abort { "Boss diameter too low!" }
+var bossDiameter = { input }
 
-    ; Prompt for clearance distance
-    M291 P"Please enter clearance distance in mm." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosCL}
+if { var.bossDiameter < 1 }
+    abort { "Boss diameter too low!" }
+
+; Prompt for clearance distance
+M291 P"Please enter clearance distance in mm." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosCL}
+if { result != 0 }
+    abort { "Boss probe aborted!" }
+
+var clearance = { input }
+if { var.clearance < 1 }
+    abort { "Clearance distance too low!" }
+
+; Prompt for overtravel distance
+M291 P"Please enter the overtravel distance in mm." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Boss probe aborted!" }
+
+var overtravel = { input }
+if { var.overtravel < 0.1 }
+    abort { "Overtravel distance too low!" }
+
+M291 P"Please jog the probe <b>OVER</b> the center of the boss and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Boss" X1 Y1 Z1 J1 T0 S3
+if { result != 0 }
+    abort { "Boss probe aborted!" }
+
+M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Boss probe aborted!" }
+
+var probingDepth = { input }
+
+if { var.probingDepth <= 0}
+    abort { "Probing depth was negative!" }
+
+; Run the boss probe cycle
+if { global.mosTM }
+    M291 P{"Probe will now move outwards by " ^ {(var.bossDiameter/2) + var.clearance} ^ "mm and then downwards " ^ var.probingDepth ^ "mm, before probing towards the edge in 3 directions."} R"MillenniumOS: Probe Boss" T0 S3
     if { result != 0 }
         abort { "Boss probe aborted!" }
-    else
-        var clearance = { input }
-        if { var.clearance < 1 }
-            abort { "Clearance distance too low!" }
 
-        ; Prompt for overtravel distance
-        M291 P"Please enter the overtravel distance in mm." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosOT}
-        if { result != 0 }
-            abort { "Boss probe aborted!" }
-        else
-            var overtravel = { input }
-            if { var.overtravel < 0.1 }
-                abort { "Overtravel distance too low!" }
-
-            M291 P"Please jog the probe <b>OVER</b> the center of the boss and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Boss" X1 Y1 Z1 J1 T0 S3
-            if { result != 0 }
-                abort { "Boss probe aborted!" }
-            else
-                M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Boss" J1 T0 S6 F{global.mosOT}
-                if { result != 0 }
-                    abort { "Boss probe aborted!" }
-                else
-                    var probingDepth = { input }
-
-                    if { var.probingDepth <= 0}
-                        abort { "Probing depth was negative!" }
-
-                    ; Run the boss probe cycle
-                    if { global.mosTM }
-                        M291 P{"Probe will now move outwards by " ^ {(var.bossDiameter/2) + var.clearance} ^ "mm and then downwards " ^ var.probingDepth ^ "mm, before probing towards the edge in 3 directions."} R"MillenniumOS: Probe Boss" T0 S3
-                        if { result != 0 }
-                            abort { "Boss probe aborted!" }
-
-                    G6501.1 W{exists(param.W)? param.W : null} H{var.bossDiameter} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6501.1 W{exists(param.W)? param.W : null} H{var.bossDiameter} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -36,58 +36,58 @@ var bW = { (global.mosWPDims[0] != null) ? global.mosWPDims[0] : 100 }
 M291 P{"Please enter approximate <b>pocket width</b> in mm.<br/><b>NOTE</b>: <b>Width</b> is measured along the <b>X</b> axis."} R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.bW}
 if { result != 0 }
     abort { "Rectangle pocket probe aborted!" }
-else
-    var pocketWidth = { input }
 
-    if { var.pocketWidth < 1 }
-        abort { "Pocket width too low!" }
+var pocketWidth = { input }
 
-    var bL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+if { var.pocketWidth < 1 }
+    abort { "Pocket width too low!" }
 
-    M291 P{"Please enter approximate <b>pocket length</b> in mm.<br/><b>NOTE</b>: <b>Length</b> is measured along the <b>Y</b> axis."} R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.bL}
+var bL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+
+M291 P{"Please enter approximate <b>pocket length</b> in mm.<br/><b>NOTE</b>: <b>Length</b> is measured along the <b>Y</b> axis."} R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.bL}
+if { result != 0 }
+    abort { "Rectangle pocket probe aborted!" }
+
+var pocketLength = { input }
+
+if { var.pocketLength < 1 }
+    abort { "Pocket length too low!" }
+
+; Prompt for clearance distance
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
+if { result != 0 }
+    abort { "Rectangle pocket probe aborted!" }
+
+var clearance = { input }
+if { var.clearance < 1 }
+    abort { "Clearance distance too low!" }
+
+; Prompt for overtravel distance
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Rectangle pocket probe aborted!" }
+
+var overtravel = { input }
+if { var.overtravel < 0.1 }
+    abort { "Overtravel distance too low!" }
+
+M291 P"Please jog the probe <b>OVER</b> the center of the rectangle pocket and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Rect. Pocket" X1 Y1 Z1 J1 T0 S3
+if { result != 0 }
+    abort { "Rectangle pocket probe aborted!" }
+
+M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Rectangle pocket probe aborted!" }
+
+var probingDepth = { input }
+
+if { var.probingDepth < 0 }
+    abort { "Probing depth was negative!" }
+
+; Run the pocket probe cycle
+if { global.mosTM }
+    M291 P{"Probe will now move down by " ^ var.probingDepth ^ "mm, before probing towards each of the pocket surfaces at 2 locations."} R"MillenniumOS: Probe Rect. Pocket" T0 S3
     if { result != 0 }
         abort { "Rectangle pocket probe aborted!" }
-    else
-        var pocketLength = { input }
 
-        if { var.pocketLength < 1 }
-            abort { "Pocket length too low!" }
-
-        ; Prompt for clearance distance
-        M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
-        if { result != 0 }
-            abort { "Rectangle pocket probe aborted!" }
-        else
-            var clearance = { input }
-            if { var.clearance < 1 }
-                abort { "Clearance distance too low!" }
-
-            ; Prompt for overtravel distance
-            M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
-            if { result != 0 }
-                abort { "Rectangle pocket probe aborted!" }
-            else
-                var overtravel = { input }
-                if { var.overtravel < 0.1 }
-                    abort { "Overtravel distance too low!" }
-
-                M291 P"Please jog the probe <b>OVER</b> the center of the rectangle pocket and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Rect. Pocket" X1 Y1 Z1 J1 T0 S3
-                if { result != 0 }
-                    abort { "Rectangle pocket probe aborted!" }
-                else
-                    M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
-                    if { result != 0 }
-                        abort { "Rectangle pocket probe aborted!" }
-                    else
-                        var probingDepth = { input }
-
-                        if { var.probingDepth < 0 }
-                            abort { "Probing depth was negative!" }
-
-                        ; Run the pocket probe cycle
-                        if { global.mosTM }
-                            M291 P{"Probe will now move down by " ^ var.probingDepth ^ "mm, before probing towards each of the pocket surfaces at 2 locations."} R"MillenniumOS: Probe Rect. Pocket" T0 S3
-                            if { result != 0 }
-                                abort { "Rectangle pocket probe aborted!" }
-
-                        G6502.1 W{exists(param.W)? param.W : null} H{var.pocketWidth} I{var.pocketLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6502.1 W{exists(param.W)? param.W : null} H{var.pocketWidth} I{var.pocketLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -36,58 +36,59 @@ var bW = { (global.mosWPDims[0] != null) ? global.mosWPDims[0] : 100 }
 M291 P{"Please enter approximate <b>block width</b> in mm.<br/><b>NOTE</b>: <b>Width</b> is measured along the <b>X</b> axis."} R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.bW}
 if { result != 0 }
     abort { "Rectangle block probe aborted!" }
-else
-    var blockWidth = { input }
 
-    if { var.blockWidth < 1 }
-        abort { "Block width too low!" }
+var blockWidth = { input }
 
-    var bL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+if { var.blockWidth < 1 }
+    abort { "Block width too low!" }
 
-    M291 P{"Please enter approximate <b>block length</b> in mm.<br/><b>NOTE</b>: <b>Length</b> is measured along the <b>Y</b> axis."} R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.bL}
+var bL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+
+M291 P{"Please enter approximate <b>block length</b> in mm.<br/><b>NOTE</b>: <b>Length</b> is measured along the <b>Y</b> axis."} R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.bL}
+if { result != 0 }
+    abort { "Rectangle block probe aborted!" }
+
+var blockLength = { input }
+
+if { var.blockLength < 1 }
+    abort { "Block length too low!" }
+
+; Prompt for clearance distance
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosCL}
+if { result != 0 }
+    abort { "Rectangle block probe aborted!" }
+
+var clearance = { input }
+
+if { var.clearance < 1 }
+    abort { "Clearance distance too low!" }
+
+; Prompt for overtravel distance
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Rectangle block probe aborted!" }
+
+var overtravel = { input }
+if { var.overtravel < 0.1 }
+    abort { "Overtravel distance too low!" }
+
+M291 P"Please jog the probe <b>OVER</b> the center of the rectangle block and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Rect. Block" X1 Y1 Z1 J1 T0 S3
+if { result != 0 }
+    abort { "Rectangle block probe aborted!" }
+
+M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Rectangle block probe aborted!" }
+
+var probingDepth = { input }
+
+if { var.probingDepth < 0 }
+    abort { "Probing depth was negative!" }
+
+; Run the block probe cycle
+if { global.mosTM }
+    M291 P{"Probe will now move outside each surface and down by " ^ var.probingDepth ^ "mm, before probing towards the center."} R"MillenniumOS: Probe Rect. Block" T0 S3
     if { result != 0 }
         abort { "Rectangle block probe aborted!" }
-    else
-        var blockLength = { input }
 
-        if { var.blockLength < 1 }
-            abort { "Block length too low!" }
-
-        ; Prompt for clearance distance
-        M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosCL}
-        if { result != 0 }
-            abort { "Rectangle block probe aborted!" }
-        else
-            var clearance = { input }
-            if { var.clearance < 1 }
-                abort { "Clearance distance too low!" }
-
-            ; Prompt for overtravel distance
-            M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
-            if { result != 0 }
-                abort { "Rectangle block probe aborted!" }
-            else
-                var overtravel = { input }
-                if { var.overtravel < 0.1 }
-                    abort { "Overtravel distance too low!" }
-
-                M291 P"Please jog the probe <b>OVER</b> the center of the rectangle block and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Rect. Block" X1 Y1 Z1 J1 T0 S3
-                if { result != 0 }
-                    abort { "Rectangle block probe aborted!" }
-                else
-                    M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
-                    if { result != 0 }
-                        abort { "Rectangle block probe aborted!" }
-                    else
-                        var probingDepth = { input }
-
-                        if { var.probingDepth < 0 }
-                            abort { "Probing depth was negative!" }
-
-                        ; Run the block probe cycle
-                        if { global.mosTM }
-                            M291 P{"Probe will now move outside each surface and down by " ^ var.probingDepth ^ "mm, before probing towards the center."} R"MillenniumOS: Probe Rect. Block" T0 S3
-                            if { result != 0 }
-                                abort { "Rectangle block probe aborted!" }
-
-                        G6503.1 W{exists(param.W)? param.W : null} H{var.blockWidth} I{var.blockLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6503.1 W{exists(param.W)? param.W : null} H{var.blockWidth} I{var.blockLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -44,64 +44,64 @@ var sW = { (global.mosWPDims[0] != null) ? global.mosWPDims[0] : 100 }
 M291 P{"Please enter approximate <b>surface length</b> along the X axis in mm.<br/><b>NOTE</b>: Along the X axis means the surface facing towards or directly away from the operator."} R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.sW}
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
-else
-    var xSurfaceLength = { input }
 
-    if { var.xSurfaceLength < var.tR }
-        abort { "X surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+var xSurfaceLength = { input }
 
-    var sL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
-    M291 P{"Please enter approximate <b>surface length</b> along the Y axis in mm.<br/><b>NOTE</b>: Along the Y axis means the surface to the left or the right of the operator."} R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.sL}
+if { var.xSurfaceLength < var.tR }
+    abort { "X surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+
+var sL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+M291 P{"Please enter approximate <b>surface length</b> along the Y axis in mm.<br/><b>NOTE</b>: Along the Y axis means the surface to the left or the right of the operator."} R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.sL}
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+var ySurfaceLength = { input }
+
+if { var.ySurfaceLength < var.tR }
+    abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+
+; Prompt for clearance distance
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far far out we move from the expected surface to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosCL}
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+var clearance = { input }
+if { var.clearance < var.tR }
+    abort { Clearance distance too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+
+; Prompt for overtravel distance
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far far in we move from the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+var overtravel = { input }
+if { var.overtravel < 0 }
+    abort { "Overtravel distance must not be negative!" }
+
+M291 P"Please jog the probe <b>OVER</b> the corner and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Outside Corner" X1 Y1 Z1 J1 T0 S3
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Outside Corner" T0 S4 K{global.mosCnr}
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+var corner = { input }
+
+M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    abort { "Outside corner probe aborted!" }
+
+var probingDepth = { input }
+
+if { var.probingDepth < 0 }
+    abort { "Probing depth must not be negative!" }
+
+; Run the block probe cycle
+if { global.mosTM }
+    var cN = { global.mosCnr[var.corner] }
+    M291 P{"Probe will now move outside the <b>" ^ var.cN ^ "</b> corner and down by " ^ var.probingDepth ^ "mm, before probing 2 points " ^ var.clearance ^ "mm from each end of the surfaces." } R"MillenniumOS: Probe Outside Corner" T0 S3
     if { result != 0 }
         abort { "Outside corner probe aborted!" }
-    else
-        var ySurfaceLength = { input }
 
-        if { var.ySurfaceLength < var.tR }
-            abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
-
-        ; Prompt for clearance distance
-        M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far far out we move from the expected surface to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosCL}
-        if { result != 0 }
-            abort { "Outside corner probe aborted!" }
-        else
-            var clearance = { input }
-            if { var.clearance < var.tR }
-                abort { Clearance distance too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
-
-            ; Prompt for overtravel distance
-            M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far far in we move from the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
-            if { result != 0 }
-                abort { "Outside corner probe aborted!" }
-            else
-                var overtravel = { input }
-                if { var.overtravel < 0 }
-                    abort { "Overtravel distance must not be negative!" }
-
-                M291 P"Please jog the probe <b>OVER</b> the corner and press <b>OK</b>.<br/><b>CAUTION</b>: The chosen height of the probe is assumed to be safe for horizontal moves!" R"MillenniumOS: Probe Outside Corner" X1 Y1 Z1 J1 T0 S3
-                if { result != 0 }
-                    abort { "Outside corner probe aborted!" }
-                else
-                    M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Outside Corner" T0 S4 K{global.mosCnr}
-                    if { result != 0 }
-                        abort { "Outside corner probe aborted!" }
-                    else
-                        var corner = { input }
-
-                        M291 P"Please enter the depth to probe at in mm, relative to the current location. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
-                        if { result != 0 }
-                            abort { "Outside corner probe aborted!" }
-                        else
-                            var probingDepth = { input }
-
-                            if { var.probingDepth < 0 }
-                                abort { "Probing depth must not be negative!" }
-
-                            ; Run the block probe cycle
-                            if { global.mosTM }
-                                var cN = { global.mosCnr[var.corner] }
-                                M291 P{"Probe will now move outside the <b>" ^ var.cN ^ "</b> corner and down by " ^ var.probingDepth ^ "mm, before probing 2 points " ^ var.clearance ^ "mm from each end of the surfaces." } R"MillenniumOS: Probe Outside Corner" T0 S3
-                                if { result != 0 }
-                                    abort { "Outside corner probe aborted!" }
-
-                            G6508.1 W{exists(param.W)? param.W : null} H{var.xSurfaceLength} I{var.ySurfaceLength} N{var.corner} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6508.1 W{exists(param.W)? param.W : null} H{var.xSurfaceLength} I{var.ySurfaceLength} N{var.corner} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}


### PR DESCRIPTION
Nesting was necessary when there was no workaround for multiple motion systems evaluating macros at the same time. We can now run these files sequentially, trusting abort to exit where necessary.