### PR TITLE
Make sure expert mode does not put fingers at risk

### DIFF
--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -55,7 +55,7 @@ if { var.roughSpeed == var.fineSpeed }
     set var.fineSpeed = { var.roughSpeed / var.roughDivider }
     if { !global.mosEM }
         echo { "MillenniumOS: Probe " ^ param.I ^ " is configured with a single feed rate, which will be used for the initial probe. Subsequent probes will run at " ^ var.fineSpeed ^ "mm/min." }
-        echo { "MillenniumOS: Please use M558 K" ^ param.I ^ " F" ^ var.roughSpeed ^ ":" ^ var.fineSpeed ^ " to silence this warning." }
+        echo { "MillenniumOS: Please use M558 K" ^ param.I ^ " F" ^ var.roughSpeed ^ ":" ^ var.fineSpeed ^ " in your config to silence this warning." }
 
 ; Set rough probe speed
 M558 K{ param.I } F{ var.roughSpeed }

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -42,7 +42,7 @@ if { global.mosTM }
     M291 P{"<b>CAUTION</b>: You may need to use small, manual movements using this interface during the configuration process. Please make sure the jog button distances are set appropriately before starting!"} R"MillenniumOS: Configuration Wizard" S2 T0
     M291 P{"<b>CAUTION</b>: Follow <b>ALL</b> instructions to the letter, and if you are unsure about any step, please ask for help on our <a target=""_blank"" href=""https://discord.gg/ya4UUj7ax2"">Discord</a>."} R"MillenniumOS: Configuration Wizard" S2 T0
 
-M291 P"Would you like to enable <b>Tutorial Mode</b>?<br/><b>Tutorial Mode</b> describes configuration and probing actions in detail before the any action is taken." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+M291 P"Would you like to enable <b>Tutorial Mode</b>?<br/><b>Tutorial Mode</b> describes configuration and probing actions in detail before any action is taken." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
 set var.wizTutorialMode = { (input == 0) ? true : false }
 
 M291 P"Would you like to enable <b>Expert Mode</b>?<br/><b>Expert Mode</b> disables some confirmation checks before and after operations to reduce operator interaction." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F1

--- a/macro/tool-change/tpost.g
+++ b/macro/tool-change/tpost.g
@@ -37,15 +37,13 @@ if { state.currentTool == global.mosPTID }
     if { global.mosFeatTouchProbe }
         ; We abort the tool change if the touch probe is not detected
         ; so at this point we can safely assume the probe is connected.
-        if { !global.mosEM }
-            M291 P{"<b>Touch Probe Detected</b>.<br/>We will now probe the reference surface. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
+        M291 P{"<b>Touch Probe Detected</b>.<br/>We will now probe the reference surface. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
         ; Call reference surface probe in non-standalone mode to
         ; run the actual probe.
         G6511 S0 R1
         if { global.mosTSAP == null }
             abort { "Touch probe reference surface probing failed." }
     else
-        if { !global.mosEM }
             M291 P{"<b>Datum Tool Installed</b>.<br/>We will now probe the tool length. Move away from the machine <b>BEFORE</b> pressing <b>OK</b>!"} R"MillenniumOS: Tool Change" S2
 
         ; Probe datum tool length


### PR DESCRIPTION
There were a couple of locations where turning on Expert mode (`global.EM = true`) would trigger a move straight after the user had been asked to install or activate the touch probe or datum tool with no confirmation. Given that operator fingers would be within the vicinity of the machine, this infers a (small - because the table moves not the spindle - but real) risk of injury, and so we have now removed the skipping of those confirmations within the expert mode feature.

There are still a small number of places where expert mode skips user confirmations but these are after the operator should have already moved away from the machine.

We also fix a small number of spelling errors and add some additional information.