### PR TITLE
Add standard and FMJ F360 machine definitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,25 @@ jobs:
           asset_path: dist/millennium-os.cps
           asset_name: millennium-os-${{ github.ref_name }}-post-f360.cps
           asset_content_type: application/octet-stream
+
+      - name: Upload F360 Standard Machine Definition
+        id: upload-f360-mch-std
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/milo-v1.5-std.mch
+          asset_name: milo-v1.5-std-${{ github.ref_name }}.mch
+          asset_content_type: application/octet-stream
+
+      - name: Upload F360 FMJ Machine Definition
+        id: upload-f360-mch-fmj
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/milo-v1.5-120mm-z.mch
+          asset_name: milo-v1.5-120mm-z-${{ github.ref_name }}.mch
+          asset_content_type: application/octet-stream

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -73,7 +73,6 @@ else
 ; Check if the positions are within machine limits
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
-
 ; Run probing operation
 G6512 I{var.probeId} J{var.sX} K{var.sY} L{var.sZ} X{var.tPX} Y{var.tPY} Z{var.tPZ}
 

--- a/post-processors/fusion-360/README.md
+++ b/post-processors/fusion-360/README.md
@@ -1,9 +1,11 @@
 # Fusion360 Post Processor for MillenniumOS
 
 ## Intro
+
 The Fusion360 post-processor for MillenniumOS outputs a relatively basic gcode flavour that is designed to work with the RRF 3.5+ gcode format. It also targets some custom gcodes implemented by MillenniumOS, used for workpiece probing, reference surface probing and tool length probing.
 
 ## Installation
+
 1. Download the `millennium-os-<version>-post-f360.cps` file from the release matching your installed MillenniumOS version.
 2. Switch to the **"MANUFACTURE"** workbench in Fusion360.
 3. Under the **"Milling"** tab, click the **"NC Program"** icon (the one with a G at the top of a document).
@@ -15,14 +17,17 @@ The Fusion360 post-processor for MillenniumOS outputs a relatively basic gcode f
 9. Create a setup, add some toolpaths and then run the Post to generate MillenniumOS flavoured output gcode.
 
 ## Notes
+
 Under **"Machine WCS"** in the **"Post Process"** tab of Fusion360's **"Setup"** configuration is a **"WCS offset"** setting which is where the work offset output is configured. Setting this value to `0` (the default) corresponds to `G54`, which is Work Co-ordinate System 1 in RRF / Duet Web Control terms.
 
 This mismatch might be confusing, but it is done for good reason - if no setup changes are made by the operator, we will still generate code in a work co-ordinate system instead of in machine co-ordinates, which will force probing for the origin. We do not allow generating gcode in machine co-ordinates for safety purposes.
 
 ## Usage
+
 By default, the post-processor will wrap your operations with a number of commands that are designed to make life easier for novice machinists. In short, these make your programs feel slightly more like they're running on a 3D printer than a CNC mill.
 
 By default, a program will follow roughly these steps:
+
   1. Pass tool details from Fusion360 to RepRapFirmware to ease tool changes
   2. Home machine in X, Y and Z using G28
   3. Configure movement options
@@ -32,6 +37,7 @@ By default, a program will follow roughly these steps:
   7. End program
 
 For each of your operations, the following steps will be taken:
+
   1. If the new work offset is not the current work offset:
      1. Park the spindle (including stop)
      2. Prompt the operator to probe the work piece and save its' zero to the new work offset
@@ -41,15 +47,16 @@ For each of your operations, the following steps will be taken:
      2. Run tool change process (M6)
      3. Tool change process prompts operator to install right tool, and
      4. Runs G37 to probe the new tool's offset.
-  5. Enable VSSC if requested
-  6. Start spindle at requested RPM
-  7. Wait for spindle to reach target RPM
-  8. Move to operation starting position in Z
-  9. Move to operation starting position in X and Y
-  10. Run cutting moves
-  11. Disable VSSC if it was enabled
+  4. Enable VSSC if requested
+  5. Start spindle at requested RPM
+  6. Wait for spindle to reach target RPM
+  7. Move to operation starting position in Z
+  8. Move to operation starting position in X and Y
+  9. Run cutting moves
+  10. Disable VSSC if it was enabled
 
 ## Probing
+
 When the operator is prompted to probe the work piece, our default behaviour is to run `G6600` which is a "meta macro" that collects information from the operator before running the actual probing macros to find the work piece.
 
 `G6600` allows the operator to select the type of probing operation they want, and then guides the user through filling out the relevant settings for the probing operation they chose.
@@ -75,4 +82,3 @@ In this mode, no work piece probing code will be generated automatically - but y
 You can set individual output settings to `No` to disable some of the default functionality (e.g. "Home Before Start" can be turned off, amongst others), or you can disable all the pre-configuration commands by setting "Output job setup commands" to `No`.
 
 If disabling any or all of these settings, please read the output g-code before running it on your machine to confirm that you have configured the machine in the way that the g-code expects prior to running the program.
-

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -162,7 +162,7 @@ properties = {
     title: "Enable Variable Spindle Speed Control",
     description: "When enabled, spindle speed is varied between an upper and lower limit surrounding the requested RPM which helps to avoid harmonic resonance between tool and work piece.",
     group: "spindle",
-    scope: "operation",
+    scope: ["post","operation"],
     type: "boolean",
     value: true
   },
@@ -170,7 +170,7 @@ properties = {
     title: "Variable Spindle Speed Control Variance",
     description: "Variance above and below target RPM to vary Spindle speed when VSSC is enabled, in RPM.",
     group: "spindle",
-    scope: "operation",
+    scope: ["post","operation"],
     type: "integer",
     value: 100
   },
@@ -178,7 +178,7 @@ properties = {
     title: "Variable Spindle Speed Control Period",
     description: "Period over which RPM is varied up and down when VSSC is enabled, in milliseconds.",
     group: "spindle",
-    scope: "operation",
+    scope: ["post","operation"],
     type: "integer",
     value: 2000
   }
@@ -668,10 +668,12 @@ function onSection() {
   // Move laterally from park location to initial positions in X and Y
   writeComment("Move to starting position in X and Y");
   writeBlock(gCodesF.format(0), xVar.format(startPos.x), yVar.format(startPos.y));
+  writeln("");
 
   // Move to initial Z position (usually clearance height)
   writeComment("Move to starting position in Z");
   writeBlock(gCodesF.format(0), zVar.format(startPos.z));
+  writeln("");
 
 }
 
@@ -858,20 +860,27 @@ function getArcVars(plane, start, cx, cy, cz) {
 // Output the right plane gcode based on the arc plane.
 function outputPlaneCommand(plane) {
   var code;
+  var planeStr = "";
   switch(plane) {
     case PLANE_XY:
       code = 17;
+      planeStr = "XY";
     break;
     case PLANE_ZX:
       code = 18;
+      planeStr = "XZ";
     break;
     case PLANE_YZ:
       code = 19;
+      planeStr = "YZ";
     break;
     default:
       return;
   }
+  writeln("");
+  writeComment("Switch to {plane} plane for arc moves".supplant({plane: planeStr}));
   writeBlock(gCodes.format(code));
+  writeln("");
 }
 
 // Output 360 degree arc move on given plane.

--- a/post-processors/fusion-360/milo-v1.5-120mm-z.mch
+++ b/post-processors/fusion-360/milo-v1.5-120mm-z.mch
@@ -1,0 +1,341 @@
+{
+   "controller" : {
+      "default" : {
+         "head_info_part_id" : "head",
+         "max_block_processing_speed" : 0,
+         "max_normal_speed" : 2000.0000000000002,
+         "parts" : {
+            "X" : {
+               "coordinate" : 0,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            },
+            "Y" : {
+               "coordinate" : 1,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            },
+            "Z" : {
+               "coordinate" : 2,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            }
+         },
+         "table_part_id" : "table"
+      }
+   },
+   "fusion" : {
+      "default" : {
+         "guid" : "ae563ab5-4736-6304-7785-dbb7251fe820",
+         "image" : "iVBORw0KGgoAAAANSUhEUgAAAGQAAABgCAYAAADrc9dCAAAdO3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtZlhw3kkX/sYpeAmCYl4PxnNpBL7/vQyQpUqKqpFaRIiOZGeEOt+ENBsid//3Xdf/Dr+qrdynXVnopnl+pp26DL5r//Orv7+DT+/v9KunrZ+Hn77vy9X1vfCvyGj//rOPr/YPv598+8O0eYf78fde+fmLt60Lh+4Xfr6g76+v94yL5vn2+H75W6Pr5WnJv9celzq8LrW+P0n77k74v6/Oif7ufvlGJ0s7cKJqdGKJ/f7fPCqL+xDh41d8hBt4XYuXrFIt7P/h2MQLy0+N9e/X+xwD9FORvX7nfR//mXwffxtc74u9i+ZUtxxe//EHIv/t+/H5/+/HG8fuK7OcflBrGHx7n68+9u917Pk83UiGi5auiXrDDt8vwxknI4/tY4XflT+br+n53fjc//CLl2y8/+b1CD0ZWrgsp7DDCDee9rrBYYrJjlVezZfF9r8Vq3VZUnpJ+h2s19rhjI5fLjiOVKdr3tYR33/7ut0LjzjvwVgtcLPCRP/3t/t0P/85vd+9SiMILZn6xYl2mumYZypz+5l0kJNyvvOUX4G+/v9LvfygsSpUM5hfmxgMOPz+XmDn8Vlvx5Tnyvszrp4WCq/vrAoSIe2cWQ/Gn4EuIOZTgq1kNgTg2EjRYucVkkwyEnG2zSEsxFnPVmunefKaG917LVkzfBptIRI6FfmpkaJCslDL1U1OjhkaOOeWcS665udzzKLGkkksptQjkRo011VxLrbXVXkeLLbXcSquttd5Gtx7BwNxLr7313scwN7jR4FqD9w++M23GmWaeZdbZZp9jUT4rrbzKqqutvsa2HTcwscuuu+2+xwnugBQnnXzKqaedfsal1m686eZbbr3t9ju+Z+0rq3/4/TeyFr6yZi9Tel/9njW+62r9dokgOMnKGRmzFMh4VQYoaFPOfAspmTKnnPkulMvGIrNy43ZQxkhhOsHyDd9z91vm/lLeXG5/KW/2nzLnlLr/RuYcqftj3n6RtS24Wy9jny5UTH2k+/j5acNZGyK18c9eR3azJni65lT3nunUOOu4SY+Y67kUgD+rpsVzVhCx5N7TGrz5AHfKeE5hrDy5UL7kc1nJngWyWphs18uSx80hb321Gu/itawT7ykzU8uBUO3RwcIe75zF2Upt1TutXgAVDmQxwGJePlTY957j+WyZ8QBY4z3LL1/dn/3gL7725A29YcX1NUNqp/oZ5gw3+dkHFV1Y2srvbfPO2gb1Go5qj28AQT6m0Smz0E/Zhwen1+bxO8EW/YSaOwxgNq2vZpkKgHnaaTWXDXsMbpZ8Md8u6FYWSGjh0DqrBgqSGopt75E3EqdTTCqYPnbOfVBBu5dIAfMzqv7u3c69KaTLRQMFu/OxTbSdT/PmvGqJqXsqYBDjM0LPc8U5fSqsm8dBBx3q/mw1lGf5OwsieHwfimcprt05ypy09yiSVQturTFCl/5Ms7bHnrXOwntZ3Cj0/MxNxcAn0yuTU+JVr607aJZKFIYhkBr0iS7i5+qlwj9YDbHK//7V/ac3/PSa4fGJuMvSWmWtyzrjAklKcWNcsGVQf77GFe7IZX2UIQrM1zRWGTtVhEGgoyUlaIm+Tp0hDxplJUp6Ru/qIpYzgyAlryVSsm0LlAmLx6NHuIdfVdXR6rYxdsjrnLTn7Gel0nKkM3pwtmFqCidtK5dF7AArENtmtVzglFoNp2facux4VjfeOcE/oCeXg6ZpAE4Zw1FQh0Im2hXFovY7o4I+4/Ry+VS3vdeE2sD/1lbjQ3vYHf1YLmBhhIcTdeBu2HNPChXCVe6abbEHwQHqzs3V3zos0dlX/b7DHKcCL/tu3kJRxbna9s3d7uNQVayaAUvfF9+/fAlIzxKpXvpnhaEmjKEAEaMTyksN11UneTihExpX+rZIDXVoKHQ0Ts5UtAqt0wH37A7IrE13+MvNS1wosGTkRIu8M9KMLJT0k59zgDBgr9Bu/oADlG+PgGGm2U7u6/o1OhUDg8Bj/BDs0xtUJflVGUz79cU/fXWQ4+IJ4qGXeAjKbdcBtiIraSaaKtyTQNczO0+6UqV+CtEGoSGP9oH/la5L6ZyKyL2HK1zeHvkbAKLP1o1F/5xEfw0+f1Hhd3zwG/R5eD7CBspncwvMoj8a6HfJIFUPzpyAPL6UzbFx6PGdEiWTzYCZ3ibEAql4io577cKNMDUAyKQDjd6IG5kHq/a2F0WLwqZ4qaqeYansodJeDwkBD9fRaqhemq6EUxv6iJv2nXqVOKAlE3A4O20MUHMlmIpnC8jamAdQlz5INNILaK7pHsof4nH8qPKZWzsauXa4nX9fICpDiv2xGr1alQqiQ8ADbiXTOnhh0Hmzxlr7DQ76PmghT3/V+sK4fR6TBp/gPaVOOTY81ifA55Uq+ivXTrt4YH7MKzEMsAX0TvnL2PZnr+7ri/yryrFflNih2pFjh26goUJljcNgSkdBzRB5itl/K5NPkahE9pmRgIM7QrGyDCwCZ1E/ueGr6bZc3uO6vPr7IsVxRjmp0dmyWGE3aFTIe31EZQF+5DYAqwkhKMT0Ba4dMOomocFhF6htlnhlCaiQdogkrLZgG/4sHvPGdtdCnU36OoDJFwQlACjpHsEsRMdxSESWCYFeAtKy9Qpl99CMYk8VMZnrpMESlDYP4hFPWPAzLdQ9RL0dXkfIdle4HL0ifCHkUAGEkUBSQe3G2LAc9BjS3nhbIiPUF2RHIQY05RiVSp7Hgpu+HwQFIpjPnl1IIbIAkY+2uIPS8QQHagY9+UPk6Zd1DeWIvdxND02l1+FORPZtIBxR0KsnT7aQ/Ri/Yqy9Qzas/TYQeuOvBi3ebyQNr24Q9V+V5Pw/LUUqkE4E/NePJQjUD+6y0dUNIbZUGDY2/IEIDq0mzAOiAZYssNQtsCmiCRipIKRUtMY5XGKV0oe06NxUEPW8MfOvymBuUT04QUBQvhSvRyxJgFeY9W6HeIFbGpgTG54BWQOrRnU8JTQJTMkABNwFcmAQ0GiTBUvUop0SxhURNWEZd6hLFEYrmA/xeb5t0fUbB7DhaaijLVJJ0ee6F5AJ9ybcQUFUIzelP1DWbTuSSADCuXQXlB/u/kDJzgFRRr9GoBQxd+PpsNACyzr9CnUbZXQL3TAwowuhBbXrmaSw0TXEF5y2fTBJcTYNMuhCdSjUTzvWJZPWd7HD0wOFGrd42w6tgxgkQ0hd9FlBZnDZXpJwl1yifemrvoHZrcXYIQ5ca6Mh4pRpwky1Wtw1zJZvmeKNks/L02LYuZE6Eob6pgvhe0MCoHGk0BcSk3U2Ejo7VM9FUbeOn1D/FHOutRB9WADcOADFETU3BVsmx1Q+6O8+aeyCTCO3tPXdEguy6//cYn1enQoXhXQjJUI/BwQ7Inq3gfNBcybkceuUOKb5Uh/33DHiOrJEhwQj2PG3oJ6zwDVUEZQ4jwrqwp/0+eYRYkGf3hLUsp5qriTWgIlD4UTW0QEKtCsq93kRoFuQT00gmPArtBRRVUFA/BME2n1uflHOwYghRQFbI2vhBSrtHqgLgtTzbNV5AS7oO4mwKBqjS3R5UPHSK6WC1oBrUaeHSvh9qnaNNgHnjxwklQaDNo2DEAeUWb/QAX8nglFaCLPRAziRKSGKUKF0KASKuIUjVJ3ITtRI0dyUtiyiZEDOFh62bN5cVcLIXbEpYQBHpSNLWoQ+Uyjocjzp5rZSHhRk7SJ/WhCyQoVSSlZ4lP2RiwgxhOIhzqyo42+w+4anbfJfhGQ2XDPy0fWt4Qf9j4vyZEhkRAFw9TTpnnXGQvZ4uIGUcosRkdi3ioBfe+N4c/Y5OvsvVaT74w9Q2GngKQ2DjUZBE0PPsANFKyOBTIKnMqoKHb3IDoxT13YIGjxGKbjEahI7alF4HBojSqnQvJhNVOceGI2iK/DJTsYKNAXO724VWHRpwbpwDGCeSPmS0uMfBH7wSTlAcgKnL9ly4GYjWVKbCDGLaLqE8aHEzdyCn00zV3gdECTCXHjA02Ggx1EEscP1Ee4I0sbSCFBDRswUcAefOjX5YkXINjoN35wto4vRD3Rdv5a33DIIvCI6w6jfjkQ5w0bC2ABqeLRAIc+ZWoYJHEIAS4wXn4iRCak/dM2L1pMzbjRuBd47GhVPA+FRjADEpa2S4YHQIBotH9eBdj6a8qKsoboRpYk6tQhQwqfQFjfZmirEhkLUkI0XUCDIRaNTxZWbOsJu8s2GC4Jxyg0IPsMZvh+Lgz1YDRXSZlCgBt88UAoUonYfJJhRHOCEQ7RfVShKVmxFyaBeUIjnw+3g+P+7IP/slbTqPx5XI4tIQUD7mNaCbX7ARvaARB5xAw4wQGXBoeai6QxYRS/jbWl1yMYfNCuFlW9KFEaeKlEcJK7T3VMO7oLHzpNyQM9SJjVMDMWgqvnggIh3xH8iRIDMlZDxdDVyhuAHWAb73JNY5LBwPgGZUra5mLCcYnuzT967/THkWbCqTTFQBiEAhWPKQ+UBWmvA9nYFaircH33xMfQqHAQeqhoqJOlH7qF7WRjUIeIWR74F1A2Ns7C/svkdU6MBQJWbh05k/JHynVDKSTWK6kQeHBGUv3xKorAQxIiWxkLpV8wSN+/uqcoTJPobajYDaregeJ74Qlnp9WjgozEggYPzAYelSSpQ1ykRHi8Zyj/FXznejEBee6AGSFtHaVTk2SvnZ/2zRBLcDsAjxkOUOcbrodChQ0iWMGlCgUdDLUg3JVHtKyXUGGgwZ92HwBPUiNIDkUJRZYeEYB91v89yO93FpPzje5OHjmDKjYyuaB8upr284RE6owEzWe/b1rxFOcg+C/Yi0Vqn8bSg+yn6WYKf/DOgOWh+lBvoSb8hFcVUW9MlzY4ryEfWNHKNcJeQDc9+MWCwFZTbpA3lWPAjuPiLY0GpZ9kIhNABNZsKg5ThnAzljwyjaqhiYKBpjI5zH/JSBfmzQFq8FiugQvfrdSCUdsFEgXB4V83UUSHNIbttN8qZwlqa6sGOpMeQJ9T8aEpKFiJVxCG1hineESOxEVdJHgYXBcUMJ+VKC11RB+HDH44ACQ9NxqARwTfOinVXbVSh7UC1SyVT9ZXiop0+g1v3fYIb82Xpb2JPxYDXNCbJRUfKRoS31xVRF6VP+fYBYw8ed3KXZSU6WMGTc7iKKJdJEYzXlXWIqzexBUwwdVSIxK7EZT8LBxYGNwTAgWg0BFlDWMxJX+EvsWsrgC7WaHkKpINkYPxB/2tzeCP/Encbi3LHb3bijqqt0knelQpwbcS75cgT+9qj1L12FFICOXjTa9cJUOkVOJOQOwl7hy7mubTdkCpCi84nUNiDuQD+k7XVSA2IwTSWfNOQimF44w1PVTZwh0gp+gQlPdLsDkUZRf9vVLExqVN7qlyVb0rWTvySYI6yhZ3xzx3IK5EazQgNzfnaam1ep31VqUqJBml+qmji1rU/cwrtV0gX+lRwC4cimoJmDyyQu8E7b3aF4G2oEQAYsl4S28Igzd014lM8ALZJX3oB9P12yx24pUHbYV6VXpaUw0I03O7KNHQEXUEryWJ8IEYt8KzJB2HyIbiGFPyMgTSfzfpcxqFWDZiWuTlw26A91+3NYO+TN+QM4siETyxlEyJgSpK2WlgI9rLkKr1IwjFHmgZXgA0spKKotZbw+yjc8rm9OrXADwqa57L4+gZ0oDwOwoGfghgGFmaE0Y3TSXNJh0fWSrAX3jA8kWkKCJiNp0Ut4JS/xQg84YsJGPE7IGx4CN/dFW407S1Q4hcpVsp+823NEEIHTkgflMWltjKm7bkTWO/CIhCGsQ98mc3xbX1A8YIWctKMBk6H247EP/mm6S7Z1rYaOoqSjFJTWhuinIvSWCcUCNLDCdgYCQPqA2SE+4ZdD7qQQvxlwnU3zbYQQNKq8QbqEFb6tI5qPXMhYoIV1pGTTqcRhdU/NaShHloA2eXX1jGAIwUiyqQmSoRGkAu0Z0mFh3dNBItbfw+ykBFkhYdE3Y88dQYAwoiol+1pySHAh0qpi7dnRstV1k96sFkwdMefd0oSygE/ZKYxw6OphUrpG3RFy2BztGFl2syDnblm4eEhoARcNRASC0d3lCl1q/kbfLmkWGzK4lyodgzYZOlf1BLMStsjxQdPrL2INRMVtTB+LESyQ5t0Sbrgd1toyEkgPQ8kfCIIW4dsksYoNJYwTDNDcuGkDrrXAQqUxoGyExKi4BxALpg/DeT149go74+8pf/gU/KIdQcFwaM4UF+OAOsEjd9ywCgENDEd1TWGoXuPujbQyYYiTJE7ol0oM3QMXQe8YDeXBpzgEQiVYU8Mzc7B466pizeTBEIa6E3DHtxnROoPUAqYSVjos9YTZKCURjs7OxwT7jd2ah/WC9r+Jb9R24sF6lwlvs2arhbLECIUAepq4GpFPYUYR/n35eoW2/t8tcNACWBpEk6VJKMD8DhNDtHgBywVvQMt7qTq5pqmdWaShuRsDr2lwZdvrH8a1xqgYSJeBThA4ilKRfsvLPD6gWGlyZZ2aQbvGpTNXqCgdmoCHR5lj3BW5UyYUbP/MKqFRGecIuQAjsBWtGrIFBPwAPYQ8kb1ohOIruv4s+ppb7AMdkGWEYw5A+yJmEIweREGkcVEHrCJ5kiEXNnV8S4kc9XAtrusKQnhT6UF2gcdhx+zW1V4yDV64Gh7moLHrENREvBVgppYgfIdG0ob1wmM5Hq49dQMymOc7q3ICD4BktGIppMKUCqhK9FTPRPFSgcjFyEUzQJHJOfUUUtBM9RLv5cHIFyjfsg5CX3QC3ybjH92ICaV9nYiNBa+IO7QRjn6iD7aeDI+87a6+EQqnw/gSHEe8SIEir+a91gmHHFrI++Wz7772zftB14jJXILso6kCsmLGIc/uzQadl7CRc6QQv52+cnPbO4uvgDYs0du++V8L0nbW7BkgGc0eS7jaselYJXp0yCSKGmuDHA9fhmjIpOhiUwYfX9zahDSr0gosZ5kEvuAQMtRwwAAuGiOgrrFO6GbLn1/YTncg6yIDDalSl36JTVyoRXtPCApWCBPrtROnQSis2o2qdiB5cXv4mQBDLpyardIMkGnOhDoUPcQHR3K7eA97E2WdZiFt8Xi5e0llFi/Nmbyxjb6jGrBZAMBtAjaNFfAFjhD+iG/lvYOYIlR6YCA0PychAAYw+d0BLR+byJxuBqp3xUSuvwzZO+98eq+m6KsiRIAoq1eo7YAyU08zpqwpBAgC/onVqIcnj6gjmSZ8LE55ZPdoJIb3D00P0Nsa+KgQT9dlrCvRZlY2qhrJAu/iqKZPHjjgXR8kX5/7dvdUSqKIQjgdS8oBz8XoYGa+5j6vXQObuk0zJ0oS3jq6txLRziP83W4ZDuKHBTDUhK+GTR9GHhBOBDfBqln6i3epvSsgaYcUftgmn0q4mRDR9colkvWIPcuAKAvEQ1EALqgO3DZOmuCuAI/cwNnUz2EpQBOwL/B9YXvJg3dEGguItM+I43iNwros1lACct4bUw1Sirvrs1fLBFmbWHPNPEfnpqhPkkD8Opdi+8kDeoDlAXLVG33bVVqgHrViM8S2YLeDPttmDPEAczYfOo6ZkCC23H0WeBKZIAcnKaDNVa6RnELDoHWEZmQfRTph6id662Dh4gO5P6bHmPkZ4SygadBogHqAQCAcNpFeYij/QOcJIHfX6bdf5oWMOQnOoQVUZGf3Unsuqgha5MCMXK1m/zgYmh3FshPBKmhe9D/QJ/RfTy4dDJ6ftwFOuN5UXVOeyVdw/AEqwRNaXBQRfp4KnhFNDpR8wUGTmQTh7k1jJIu9gmmUOv60Rz8mjvqwSKyiyK2DbprcJLOkK0PKCEZVRh4J22iQCYNtXNo8aSxDhpb025Hody3G0ZjIIwWPNvkfFHZGwoAQi5GlEQ3HRKIF4DY0iwSKSbN8eJ5lsva5UUHPOymTIJ2LIFRQA0PSA1o8tMG4ZF+1TKo1aaMVXKk0zO4z9GTBlF4c6zNoI8Lep6O2KXpgHXWkYQ4NJY17dW0m3IEEIkvFtNAOFp7rAOoj+vK9LfjaE5ZuCCQhKTjRXDHFvbS3iGOGCPH/YAdI6sNOVpBK7qFkGJXUKq0CBI/NKm0La47XIHehVbxraXIsY/9ojAmLaCNykg9ZQCvJcyzPAVeV1YU/FITeZ3gO7MB8Mfr9FEYfvekGCB7F0WSTJNKEJp8ZGCKuh3yPIgWhB0aktBKKe6JeFCMbdMpSydvddrusjxQHQeHD0Ft8CARydE0iqCYlMuBoSrTBcKos4aP1WSqdOYN0aZNBG2jZc170Qvv9HCjUNqG3aPusbWPRU/EqmkNBLVIgXAZbaRtAbQzchr8sKbD3dp8uu0d9BuagfkWonY/awY9U4E0FV1zlAcmXjBOhWEth+bCUcMwTIhMNEXcN8YHwYgUPMTo+ZwiqGRl4BygPbIDdyVE5TV0PoPqRyV67AhAQWTeqRITCdB51E6cOi6kPTNSVHToD6QHe4/TfU1HdEjt1TCJOt/hAxsjZtkjNBhJzmBBkTjXeAiNtabRiDoGUDV4caf6Z5+t4QmBhX6010nTBIlq2hTWNAGarvPQmJKq2q7JGuJlbVjjBiItsiQcqlg1R9M+3tLhrC3imKIMZEQLoD4Xg2T1fymwmm6bboAGqAikIbwWLGh48bDv0B8aHNKjppPEiOqoEwcwU+9vA4u1IXr3IdJB/gqEjrInOEgowXQOxB+gGV+Bw6AqeXvXYdQ7d8Pu0HaIGI21uIjmQeHAN5SQ7qUUlOTQuqu//X/ROyIq4TgVAjxchxDA4aAFUzcIQctXSIK0S7dpRJh0rKsLIRFXgLOmw1yPJCC3NX7WFgetvSpNDBxoQKcDHlQNliSPaEOH2stBu8vExuywoPjkgqJXOdM3uy1KtAXDLPeO7IcqUl3YyBoWdJvBr26oLZRk0TmeQ/O06wTckDJ35NYNIarHi5SNDoVqCnV07phrbt6GekUiASIGVAdbErFig5W84yE2eZTsVGdDGJAhb2PB2gJElclwqhMJCSI9vOJkdeno8B7sBXphNdzDxTBGCTsixXUGj7Djc3iYJQszVW7UIrx/ilW1TtJ5HostIi90Mgcq2E67hCryUrQbg7rBiOmshjQTCiFpJkYO9VhEiEI5Gr1INmFd4AGygqaksjFuoYSDZjGk/p6INgBKU2KoEeURdCwvknABgmQnPolVd7y09u0T9Wua8dG09R2I4jZ96v93KOEd6wySyer4/NaaMFAKboSf5sKhx6jTiDRm4rkGIuLQGWrfd5IXl5EQN3kb7oEnHrLcwj2JTIhpHoC14qDpqylYM/QwXqlLQ6J2BGQw/zgoKvpPVADeaLhSawMuPOIIuCd+OpO6etVZaFqbdWMDvMbcy2mQatxkIGWFvV5nFjNcA7YDIF774vbNg1BDR4wUvCxGpFlQdlmeNTsdT+CCxHXDhXjRxoWG9m0wWGUd7r3fLPlBZNhvJ3Bql+4iOLGQpnaZxQVpDK9j6/QWvvtqblS0AbnlLMfSqQ7w+1AwTRtBlpNm3YRFU5d+Dh6HqnA67g80QPSap73TCmKmd0rF8CcNr8ttSRGUFNHRc+qwhtAXCWoNm68xvzxtE4qCj/KdOX9kHnX9Jfee3UdvrEjFdPgPWWZl6ghCA8jAVnQpDekSIqJpfoWGiWe1fPWMOiQS0Q6UN15F+QdQtsEWUDGND6sMHRHJVLba1h/9HyxcotI8cAQKQLwVO0LzjejxrphCHnB6ehrVABsGnbyLmNXHNVVj3aYW0dikawvjaBt6g3lqRWRwbxsIF+V/ZrSSbzpUSLkYUM1SuraMdZ8ekyPsdCYijMrPQmZkFLwy0WsLcYreqJoADQqdUKeJQESNewR4uTrvg3g5ByOFiODGOk/ZWAsum9TxwT4Qq9zSjv4HH9SvVyfhqjQ5Q/NUMYeBR1BReVM0N+juv36cHwIdiF04a3rFEr/19tFCRGj1gH+qCR8W5WSjzp6N+HdPoLpf/oB8bJyY+z8aqL9AcJwzPwAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVfU0XRioIdRBwyVCcLokUctQpFqBBqhVYdTC79giYNSYqLo+BacPBjserg4qyrg6sgCH6AuLo4KbpIif9LCi1iPDjux7t7j7t3gFAvM83qmAA03TZTibiYya6KXa8IohcDiCImM8uYk6QkfMfXPQJ8vYvyLP9zf44+NWcxICASzzLDtIk3iKc3bYPzPnGYFWWV+Jx43KQLEj9yXfH4jXPBZYFnhs10ap44TCwW2lhpY1Y0NeIYcUTVdMoXMh6rnLc4a+Uqa96TvzCU01eWuU5zBAksYgkSRCioooQybOqrBJ0UCynaj/v4h12/RC6FXCUwciygAg2y6wf/g9/dWvmpSS8pFAc6XxznYxTo2gUaNcf5PnacxgkQfAau9Ja/UgdmPkmvtbTIEdC/DVxctzRlD7jcAYaeDNmUXSlIU8jngfcz+qYsMHgL9Kx5vTX3cfoApKmr5A1wcAiMFSh73efd3e29/Xum2d8Prqtyvx5B69QAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfnAwsQLgE3EuaBAAAbGUlEQVR42u2de3Bc133fP+fcx74XizewBAiQICm+rRdF0pJsSdHDlWI7rqNYmU46mdZ12rRu7KZN2kwnncYzmWkysVOPM572nzR1nbhW7YkT15atRxVblEhKNB8iRRMgCRIg3lhgse/d+zj9Y+8udxcL8AVKiojfzA4G9969e+75nt/v/H7f8zu/K7hz5XvAJ/bs3s3g4CAAf/v97wPsBM6+V43S7lAwfrxr27aHd2zf7uvo7ERKCcDgwADFUumpVCo1DFx4Lxqm36GAbF1IJiOtnZ2ULIvx8XGEELTHYljF4hagZV1D3l35QsmyYt09PQjgrWPHSCwsYGgand3dhMJhtbCwMA9cercbJu9QQH4oYKryj1IKpRQjo6O0t7fjM81fAR59Lxp2JwDSBWwHBmqO/Yll22dRqnrAcRxc133PG3snAPK7ntf07Zpjr/hM8zEhRP2Eqr/3U+oHfVJ/4eCBA091dHSQz+cfeOnll/NAABjMFwrfc5X6uHfdKeAe27addUDWXsLAEcABNu0b6iMUDPHysbcJBYO+bC53EhB+n29AXtWQbcAJTdPWNWSNZbsQ4kt+n29n5cC50TF8psHM7CxSSiGl3CuEYPeePUSjUYQQHNi/33/4yJE9O7durcYk64DcutynSfnPdV3/5dq54O9+dgqUwjCM6jEhBOFwGNM0AYhGowBYloWqmejXAbl+8QHPALW99zEFn5VSYtt29aDrOCggEgjQ091NMpFgYWkJ0dgRuk6uUAAgEomwZcuW7efPn9/vmb91QJpINxD1/Nj2VvhO5UR0yyb8kfCyL8wupckUSgDEYjEGBwaYM02KllUGSikqnlbA72djXx9SSmKxGJZtPw7MrQOysvwh8E8ATOAXatRj8KMP0tq/ARrMzYnRK4wvpJbdyLZtkvPzGLpOIBRCCIEQgtbOTgBGR0c5febM14D/tG6ymssbnzKM/V1KIWwb0WCrLv3Pb1H45NP07tpe96VafGzLYnFujjPDwxSKRd45f577olFKts1rhw6953PH36fA8OizhrG33XWFdJxltr88G9skjp9i4tSZFW/iuC5jExNkc7kqVVKdZ94HEfrfB0A6gf/1acO4r8V1g4brLjNJdZhcuERhMVl3bHN3O/1tLVW+Kp3N4rpuU21QSjE+Pl7nEKx7WfUSAv5Rh1LIa4CxkrSEAvikIrm4uOr3hRAYhkEhk3nPTdf73mQJ274pMCpSzOeZnZnBtqzVAdF1TNMkmM2yO97NJz764buAfeuA3I6gJRAgGA4vA6HWXBVLJc6MjNBy6BD3bxlgqL/vM8C/XzdZt0GWkkmE61LREUcITMOgke19P8gHHpBu4B/fv5f2wY38/CtfrwQinLJt3PeJq3vHADIyOUtyYhbfzBSZ8Yk6l3k7kAGmPZPleBQL61zW7ZNMoUQhX0BevoLtBZQVGfiVX2JRN5ken6rOI1LTwHHWAbmdUoxEcLZvx83nMTxWt5RMotk2C/kii4uLdZP7usm6zZIPh7FMk1KxSCgSAWBB03j9jWOMT001Rodku7rILKXJZTLrgNwuMUwTw1v7qPF7EULUaYWUkksbNhB+Z5ilTJrurq7gzOxsHJhcB2QNRKFQsIz/cl2FlBLDMCiVStXjjuPQ2tnJ1t1byRVLJE4Pf2xmdvYnwJb1wHAN5J5NfeyMdzaABM898RAHd2+r8lZSSiLhML/4zDOYpsnhkTGOnL3AwuwswLvKPH6gARFCkM+kmZ2bq39oIRAIpJRIKent6eHAgQOcOXMGy7KYnJpic0cLTz94P3t37OgH3uJdyvL8wFMnhs9PJBxeOXDs6KCzrQ27WKSvrw9N08jn81wYG2Nseo72zk4/cN+6hqyBJFIZspZNIBC4qjXA5MISi9kcAD6fD79pks9m8Zlmdb558fAx5haT7LtrM//yuU8RDfh/G9izDsgtyNh8ksnkcvf19JUZxhJLywPJZLKOTulqCbMl3sXd27cB/Bdg/x0PiLoWASjE1c9N/cDyYNAwDLq6unARlGybkmWzY2iQu7cNtQKxO9rtVT4flEqwwjKraxjgJbcpKZfFFqvJsqVbpUAp+vr66OvrIwO8cOIcLvDZX/4kR06d+aMTwxf6gN+6o02Wa5qoJmmers9XBUM4DpnXDnP6L5+/Jq2+ODdHOpnE9dbZj506xbFTp+iMx9EaEq6FEGhC8IPjZzk+euW2u8HvZ0CmgP1HSyWroBRK16+CIgSuaVbNlLBthG2jShbW+AQjL72Ks8rauFIK4XW2qxSWbWM7zqpmz3ZcHFcBPAd89U40WUXg6AnX/VzUtn8/tGHDJqEUxZkZVIUq90xOpXMRAooW6rUjzLe1MbawRCKbrx/xQCaVIl8somsaVgU4pcikUgTDYaSUZDIZkktLoBSuKkf2iUQC4DTwwzuZOvkfP3Gc2Gb4rO26u6YBWyloogGVhDek5NALL9eNeCnEsv0fumGglML2AJ6emmJw82ZyuRzJxUWy6TSO43Dh8mUi4TCFYnEdEE/+9OLYmASeWuWa/lgstqO7q4uR8+eXpfO0tLSwIR4HIZiZnqZUKqFrGhhG2VwBaS/rZG5ujlI+T1sshuM4FAoFdMMglUqxuEqyxJ0ECMCXvc9K8psdHR1/tmXLFs4NDy872d7WxtDQUDneSKerpGII6PQ0aVNXFxG/D5+uUaEcNU2jf8OGqpYtplLrgNyoBAMB8oXCiu6v7Tg4rosmJbs1je0+X9nknTzJric/gt8tcuSd8yjPNdbexT0jd+ou3KseV83HNX3eujqMT04y1NPOrz7x8Lu6zH5HFg7QpEQKUd6g47rgudOj27ay9PbPuTB+Bdd1mRu5wOhSitHxMTZv3LiuIWspyaUlpiYneWCon6ENvUQjEVylmLZtRiyLEcsiZZpcmk0wkyzPE+GuTto2DzI7Pw/AEwfu5XOf/vjjwBfXAblFWVhYYHz0Aj2tUaKhEIam4ToOw0rxiuPwSpNsE+W6SMfhCSCeSrGxrZVYNLIbeHrdZF0PxeI4WDVLss0m88VUGsu2cV0X23EIB4O0xmIEwmFMvx+AtvZ2DNNk9sJlRn52inh3N5qUZNMZcsodA46vA3Idks9kSM7Pr7iTNpHK8N1XD9e7w62tbOzvJ9bRcTVmaWsjl80yNz3Ni67Lpniczg0bOHZ6mJOnTn0H+J11QK5DQtEo7T09uOfOLTs3ODDAjh07WJyd5eLlyyRTKbZt3oxhGJx4+21Mv58PHzxYvT4QDNK/aRN9g4NVsrKvr49AIPAbh48c6QeeXQfkWoAkEvToOp9UCmq2QQPIdBpzdJSuhQWefvbj6KaJEJKZRII/PXcOslnODQ+zedMmDC8Ru5E19tbgg9zGNZEPFCB6KoVZKGCWe6/+ZC4Hly8jCwXaW1ow/D5mEgtMzFxNgBgeHsbv89Hd3Y3fm0/e9Wf4AOHxjg1/O+s4H288ERCCSGURC8H41DTSNDk/Ns7zL75ad+2pt9/mo62t64Csgbx60nWTJ123vfHEw5rWtbGS7GYa/OAb32ZslfC7UCgQCATqqj+sA3JzcgJ4sPHgTx3n13Cc/0a5EtA15cjRozywbx/d3d3v+gPcKYHhN4CHb5TjWjdZt5nCutYF+z70IQCibW34A6sq08M0T8D+BuWCaTct4gMOwh9yNeswChxodlEsEmGgv5+AN5G3tLdj+nzYlrVsW4KQErlC5bl0JjP+5ptvPg/89loB8gTwDxqOfQUYv00d1n2rI2pVeyzlP6Sm1uJKFRvCwSDxnp6rXlkoRDgcRpeSYr5+Td4wTfyhUFMNKhaLLC4uTrz51lvfAP7DrZqsRzd0d/8LhPjUbHkxHwDHcbKu6166HR0mhOgVQjRlThvLX9zEveuCO+UlKjT1qopFpsqZ7mUNiURQtk2wSafncjkKxSKtbW0A+Pz+6tq9z+cj2tKyAfhXtwrIXk3K3zNN83G/30+yZpmy4Lr/sTFiXcutX6tVcHO8EkqrdfqKE0ZDHlezyLtyvLENbbFYFQylFJZlVTs9k82Sy+dxHYdgKITp9yMoFz9zHAfLsti8ebN28eLFfcBJoHQzgHzTNM3d03NzV9Niahrc+HBrUQ+k2X2bdepqv7UWNRKllJgN8UbtELAdh5FLyw2EoxT3339/ZYQyNzfH8PAw8Xic7XfdFbh48eJRIE5NfeDb5mVV0mmajeC1LrV6I/eTUuLztq4VisVq23RNqwvyas81k9GxMfp6e/GZJhcuX75mJuTSwgIpb/PoxMQEY2Nj1WnrluIQXdfrRovjONi2XW28UgrbtqujVtO092U1BACfaa5oDn2muWrighCC2fl5rkxN1T2fZdsUikVKjalAQlS9owbNP+45RL9x8xpSm1xWyZutpGw2MTNSyuoE3KwDlFI3VI+qco/a70gviXolqZRccl0Xt3blTwhc16XkuuVBJAQBv7/uXq7rVlOCzJqNoY2mu1Qq4XrP6bouTsMKYyQSASGYmp2t7aderw++4LpuiNXTmOoB+cyTj5IrFvjBa0cxPDNR26hGr6e2XmHlXO2xWjBuxAmoAHEj36lkvLuuW2cjattXOV4slTANg77eXlpaW8teUhMnIZlMcnF09Kq1qBkgyksvrXOHG6xLQ1+dB965IQ0ZiPeQzuVwXZdmXlWzjq1oh/DSNDUpidfwP75gENM0UcCpU6cA2LZ1a92OpmayLCATgmAoRKFY5PJV+wzA1i1bMH0+UArHtsmm003vadk2V6amKJVK5VdTdHTQ1taG4eVkQbmUU8VCFPL563ZeTJ8P13EIBINs2bIFpRQnTp4E+N9A3vv7wo2bLKWW28catKPRKO3t9WRqOpUinclgGgamYdBVsxQajESqI7ACSG88TtTbwK+8TqyMwIrZc2ybTLK+OlwoGiWXz5NNp1FKkUgmUUox2N5edVGlFOhG2eRdmJjGqqkcblkWV7xCAcViEc0wcJTC8UrDKiAxM1O9PrUCsJVoWilFoVDA7/cTCIVACPzBIIFQCNd1K4B88Wa9LEsp5bpKydXsery3ly1b6rdsT05OMjIy0pSQy6XT5LwOrAW98r/jOJWtx4xPTpJIJhmIx2mNxZaZkawXGw329+O4LoupFK7j0Hb4MGFNQ2kaLQfvZ+vBgwghODvyPCeGL1o1no4EqjbljcOHrzmXreQUSCkpFYscOnSIRx55BE3TCASDjQP4pmKDWtv0Vwj5XCjgp7hC5kbjBO0zTXRdrzNxjuuye9u26sOkMxnONMm1vV7Zf889q07oCpj3XM6De3bwkXt2I4Tgz/7yeU4MX3wceNm79D7K25uv27loBMQ0DDRNqw4oIQSO43Dw4EGCHiC5fJ6XX345S7kG/S1RJ58XqCu5fP7fVv33ZruJarwsTdPKebKexyE8+uDSlStVpG3HIRwKVRu7FhVApaaVa+x67Wzr6iqD70pe//koD+3Y3Izh1W4FDL/PhxCC7o4OWltacF2Xcxcv1vXH0tIS54aH3wQ+vRb0+7xSaknTtKr7Z10j9d7yYpSqSfJGct6zy41mx+/z0dfbS7FY5PLExLIH/qefeoaejjJHVLJsfnruEheHh5d5NJqmsZBOMzQ0hBSiGky5wEI2x0tvvMnUXALgD4DPV0jdmwWj8gy9XV1EwmE0TUNKydDAAK2dnfg8x8BxHGZmZoq3QsbqzX5Y91C/FiCNo11528OMGs1yvBjAZ5plW+v3EwoEqlS3An7xoX0IIN7VSThYnqALJQupRolv3Mi9g3GCvvIgWUyl+fPv/RDXdQkFg3R2dtZF4a6C0cUMv/rMk+iadl3bmLP5Al//9l9z4MCBOjuey+UYrjG3pmlWn014MU04HGZ7bydBn4Ed7+CejT2DX/vWd/8A+P21AOQUSr1q2fYj14oFGu16KBCgtaWFcS+61aQkFo3iui6TMzNIKatA+3y+6qhSQDQcAgTpXJ6lTLm2bsmymJmaor272wPRj5QSq+bVRKVSaVkbhRB0dnYRa21D165vQdTw5Rns68PQdaLRaFVDCoVC3XOGAoFqrKGUIp/NMtTZSn9nKwGzfHwh6O/zvKs1AeRvbMdJ2Y4TWa39wF7TMMALyJRSBPx+Yh4glmWBYdTR14VCgVCNJ1LrVfzwjeNVlU+mUkzPzaGUolQqMTY5yfHjxxns6yMUDNaZw3g8TuPbECpyZOTydXeCY9u0xWL89LXXeOrJJ6sm2+/309/fv6KDUyqVuKuvuzrQ1oS7a3LsVeD+Vb7TC0yaponwUvptx2F+cZH5xcXqiLIsi/HJyRuKuBeSSeYWFqojvaJFK3lZi+WXtNxyJ1iWxWnPNF1veyvF+9d678hNP02lkwzDIOD3Vz+Nk37pBvbkdba301ezcleNxgcHm2rXWolhGNy7ezcAielpSg1OyYr0v5T86z/+GonkUmMcIdZSQ64ls8BgNpc7E/D7Q83cw6Jn213Xrdp7TdMoWRYXL1+uuoqhQKC6f682rqjMIRW5PDFBvLu76QreWsr9e/eW23adDLZSiicefYTXz4xQyGXI5/I4rvMWt5D3ezOAOMBl13VVM/WuNS+1cUuFAMx4byeoxCVSyrp4p1AslreY1dw7XyiQWFwknclg2TZ+v5/CdY7iZhJtbUXUDCTXcUgnk+i6TqS1Fb1Jglw6mSSdzSKEIBQIlIuexWJMTEyQTqVYWlpiKZ3Gdd3NwH9d4afPc40EiJUAaQP+HSunJ7mU36uyYmyymu2vvXY2kaijvZu51iXLIrG4eHXkeoTmQjJJLBq9oUWsxaUlnAY633VdMktls2M3LOlKKQkFAhRyOezyPnWK3rNJTcMplejo7KSnt7e27z7RlDS17am3jh0reibtj4GF1aiTivRtgmcH4MuHhEBp2ooG0fQWgWoplZXmjIqmqBrWWNSs8AFsdxzCSmG1trLU3k5maalOU4QQ6IZRJvO80RLQdeQNLJLNJRIsJJPVvelVM+k4TZeEQ4EAg008LeGRiQoIesHitRyHxcVFTv7sZ+xXisuu+28uKfU8cGU1DeneCs92wpd3AkkpmTIMMqt4Mq5XFXolqrqSXFDrv6sVRsMmy6LdtimFQiS6uphuojk+v5+ol/EB5TIZdg33pqDu/2aOg+M4y9Z6HMdB13V8njmqdpCuL69o6g2mcMu1XyrtOg6245BMJhl56y12BALssCwmXffLwOi1APlnXfClvd6DHXQc3iiVOH0Ly7S6R8VUNMiy7avclxD4Pde2dnyZ58/TMTPD9Nat17x/2CuOXNu581OrM949HvfV1FZ3dS2rCHQrkkmlmJiY4PylS+yVkgccBylFhXqWFvVvcGrUs4c3wmO1KcZXpGT2JgHRDYMdO3awe88eTp8+XY6sG+YW27bRdJ1P53JEa8yIVioRn5pipqenrohZZRQDzE9Pk02lqjR/Ln21AHJHTw+O46xaFaiZ5LNZDMNYM1CKhQK5XI5sPk+HZTEQ8HPP7/4WLckUzM59ZlwpG/hJMw35ylPwa/1r6EY+6rrs7e8hvnMLnd8vD4Wzus5xjwWueAefyeUwm7DAtxJznT17llgkUserNUowEsHfJL5Zq7d9LiUSyzahutkcf/HX/5eFC6Ps0DSelPILP7btdo9uqQOkR4P2RodPGAbSiycaXdTV3oxp6DqmEBQujzFjW1RCxq22jSEEr1PO8dznOPhWCXeHpqeZ6Owk52lGMHx9ywyRYLAus0Q3DEIN5k3T9RvO7SoVi9X0UqUUkViMfDbbVBOtGq5N1zSkz4eUgic//ADfzebQz4+iK9UO9DSarM8/Ds90SNnpSsmcUlTIrAnTZK6SVeK9GkgKUa59K8SymKEiD0pJhxDI2XkK50cRngaYSuF0dpJraSGQyXCXlNVzTT25TAbDNJGxGFokgmGaVWLP8tzQ2g4ORSKYfj/Kdeuchoqb6g8Gy0Do+k1pglUqkUunsS0Lx7YJRiLVvAKpaUhNQ0hJviYnoJIdGUin6TdNtj7+CO+cv0hmehZ/eWDKi2UsjlZa9Lk22GkIwaQQnL3OxmmaVka+yYP5XBc7EqHY0lJ+j9RVe4DQ9bKmCYFqMCnBfXcTeuxhMlf9elrGx4kaRtXbUUqRTaWWDQSlFJbjYDlOdfHKME38wSCGl4hwK2Jb1rJ3WZUKBQzTJBAK1X1qSS6/z0c4GCyX8bBtlmZmKeXy/NTzNHuF2Pmgpv0O8JwO7NkFfh2Ydxx+TPld1nU2VQjUCrmxmqZV6Y5aecl1eWiwn34pwassXWppwbZtUnNzXHJdtjW5X2zrEFpHB28mUgwVCvi85VmtVEKzbZxV5oRCocD50VF0TaOvt7ecJurz4Q+FblgbXNctd2CN9gUkhEM+CoZkcq4c0yVmZ2lpb6+L7pVSlBreV2I7DsIwyOULXPj6n6MDu73oumXjBvZ2tPcdOnbyr3Tg1D7Ke71SK7CNemVE36A8sOsu2nWNS4ffBCEYHRjgQiLBRE12R7OZXAFFTePMpk3ck0ohHIfI0aPIe+9lMR5f2bwZBps3bqzLx8qW6QzCLS11HXQth6GQz5Ndukoadsbj3L11Ez2tUeYXk/zeV//7Tfkc54FfB3F37SDcs4vW7Vvh2MmyD/zrNN985/r9HHYcRq4x+dle1vcy0st1eUQItvn9TD72GMePH2d6erqqWVt1nQcdB9nAS2V6erjS3c32cirN1ZW9JoAsLSzUsbMhv4/nnvwIKMWPDh3h/7z0dwA8/dB+fukXPlq97pUjb/GtF165Wev1EuW9NDfLH9Z11q5du4jH47z44otlL+vQCqSWKhaZBApeGuZqrGcjRWIaBlJKRoBZIUidOFEpIomuaei6zowQvKZpPOTzIUulqt0NJhIM5XLLg6yLFzneoF3FQqHOwzF0jW8Wcyggly981ns8pucTe775/R99+yphWfxN4P/dZKdmb2Eqcii/AutFoH9oYID2Gu0VTbT3KPBHN/ljISHEX1TWCmpBrM2FbczV3a8Uosl7bpVnZwWgNI1J4G8c5yTwpetsz2vATA3p92jNude5wSS2NZaPAf+5PRZ7IFZOaR1/5+zZL+pSysYJuQXoW4VCXk38SqnNgGuv4tE0Jiofan5ZDPhi1APE6Okh6bowNTVDzbvUb0AWbvJ7t0teAFoSyeRdiXKW5hzwHTRNq61ypzyy66vvgwYP1rZraONGNdjfr4Af8QGX0w2f9wMYEW/SrAIipVThYFC1xWKHgLtYl3dVPtGgtUpKqbZu2qQ+tHOnovw+yA+k/H9oahs4dZUIOwAAAABJRU5ErkJggg=="
+      }
+   },
+   "general" : {
+      "capabilities" : [ "milling" ],
+      "description" : "3-Axis DIY Desktop CNC Mill with extended Z, for use with 120mm clearance FMJ (LDO Kit and self-sourced)\nX=0 to 335mm\nY=0 to 208mm\nZ=0 to -120mm\n",
+      "minimumRevision" : 45805,
+      "model" : "Milo V1.5 - 120mm Clearance",
+      "vendor" : "Millennium Machines"
+   },
+   "interactions" : {
+      "default" : {
+         "pairs" : [
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   "kinematics" : {
+      "default" : {
+         "conventions" : {
+            "rotation" : "right-handed"
+         },
+         "parts" : [
+            {
+               "control" : "driven",
+               "direction" : [ -1, -0, -0 ],
+               "id" : "X",
+               "max" : 335,
+               "min" : 0,
+               "name" : "X",
+               "parts" : [
+                  {
+                     "control" : "driven",
+                     "direction" : [ -0, -1, -0 ],
+                     "home" : 208,
+                     "id" : "Y",
+                     "max" : 208,
+                     "min" : 0,
+                     "name" : "Y",
+                     "parts" : [
+                        {
+                           "control" : "driven",
+                           "direction" : [ -0, -0, -1 ],
+                           "id" : "Z",
+                           "max" : 0,
+                           "min" : -120,
+                           "name" : "Z",
+                           "parts" : [
+                              {
+                                 "attach_frame" : {
+                                    "point" : [ 0, 0, 0 ],
+                                    "x_direction" : [ 1, -0, 0 ],
+                                    "z_direction" : [ 0, 0, 1 ]
+                                 },
+                                 "display_name" : "Table",
+                                 "id" : "table",
+                                 "type" : "table"
+                              }
+                           ],
+                           "type" : "linear"
+                        }
+                     ],
+                     "type" : "linear"
+                  }
+               ],
+               "type" : "linear"
+            },
+            {
+               "attach_frame" : {
+                  "point" : [ 0, 0, 0 ],
+                  "x_direction" : [ 1, -0, 0 ],
+                  "z_direction" : [ 0, 0, 1 ]
+               },
+               "display_name" : "Spindle",
+               "id" : "head",
+               "spindle" : {
+                  "max_speed" : 24000,
+                  "min_speed" : 8000
+               },
+               "tool_station" : {
+                  "coolants" : null,
+                  "max_tool_diameter" : 80,
+                  "max_tool_length" : 160
+               },
+               "type" : "head"
+            }
+         ],
+         "units" : {
+            "angle" : "degrees",
+            "length" : "mm"
+         }
+      }
+   },
+   "machining" : {
+      "default" : {
+         "feedrate_ratio" : 1,
+         "tool_change_time" : 120
+      }
+   },
+   "post" : {
+      "default" : {
+         "path" : "user://millennium-os-%%MOS_VERSION%%-post-f360.cps",
+         "properties" : {
+            "jobHomeBeforeStart" : true
+         }
+      }
+   },
+   "tooling" : {
+      "default" : {
+         "has_tool_changer" : false,
+         "number_of_tools" : 50,
+         "supports_tool_preload" : false
+      }
+   }
+}
+

--- a/post-processors/fusion-360/milo-v1.5-std.mch
+++ b/post-processors/fusion-360/milo-v1.5-std.mch
@@ -1,0 +1,341 @@
+{
+   "controller" : {
+      "default" : {
+         "head_info_part_id" : "head",
+         "max_block_processing_speed" : 0,
+         "max_normal_speed" : 2000.0000000000002,
+         "parts" : {
+            "X" : {
+               "coordinate" : 0,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            },
+            "Y" : {
+               "coordinate" : 1,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            },
+            "Z" : {
+               "coordinate" : 2,
+               "max_normal_speed" : 0,
+               "max_rapid_speed" : 0,
+               "preference" : "negative",
+               "reset" : "never",
+               "reversed" : false,
+               "tcp" : false,
+               "zero_position_offset" : 0
+            }
+         },
+         "table_part_id" : "table"
+      }
+   },
+   "fusion" : {
+      "default" : {
+         "guid" : "9e42a1a3-4682-e0f7-3769-89a25b2e3694",
+         "image" : "iVBORw0KGgoAAAANSUhEUgAAAGQAAABgCAYAAADrc9dCAAAdO3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtZlhw3kkX/sYpeAmCYl4PxnNpBL7/vQyQpUqKqpFaRIiOZGeEOt+ENBsid//3Xdf/Dr+qrdynXVnopnl+pp26DL5r//Orv7+DT+/v9KunrZ+Hn77vy9X1vfCvyGj//rOPr/YPv598+8O0eYf78fde+fmLt60Lh+4Xfr6g76+v94yL5vn2+H75W6Pr5WnJv9celzq8LrW+P0n77k74v6/Oif7ufvlGJ0s7cKJqdGKJ/f7fPCqL+xDh41d8hBt4XYuXrFIt7P/h2MQLy0+N9e/X+xwD9FORvX7nfR//mXwffxtc74u9i+ZUtxxe//EHIv/t+/H5/+/HG8fuK7OcflBrGHx7n68+9u917Pk83UiGi5auiXrDDt8vwxknI4/tY4XflT+br+n53fjc//CLl2y8/+b1CD0ZWrgsp7DDCDee9rrBYYrJjlVezZfF9r8Vq3VZUnpJ+h2s19rhjI5fLjiOVKdr3tYR33/7ut0LjzjvwVgtcLPCRP/3t/t0P/85vd+9SiMILZn6xYl2mumYZypz+5l0kJNyvvOUX4G+/v9LvfygsSpUM5hfmxgMOPz+XmDn8Vlvx5Tnyvszrp4WCq/vrAoSIe2cWQ/Gn4EuIOZTgq1kNgTg2EjRYucVkkwyEnG2zSEsxFnPVmunefKaG917LVkzfBptIRI6FfmpkaJCslDL1U1OjhkaOOeWcS665udzzKLGkkksptQjkRo011VxLrbXVXkeLLbXcSquttd5Gtx7BwNxLr7313scwN7jR4FqD9w++M23GmWaeZdbZZp9jUT4rrbzKqqutvsa2HTcwscuuu+2+xwnugBQnnXzKqaedfsal1m686eZbbr3t9ju+Z+0rq3/4/TeyFr6yZi9Tel/9njW+62r9dokgOMnKGRmzFMh4VQYoaFPOfAspmTKnnPkulMvGIrNy43ZQxkhhOsHyDd9z91vm/lLeXG5/KW/2nzLnlLr/RuYcqftj3n6RtS24Wy9jny5UTH2k+/j5acNZGyK18c9eR3azJni65lT3nunUOOu4SY+Y67kUgD+rpsVzVhCx5N7TGrz5AHfKeE5hrDy5UL7kc1nJngWyWphs18uSx80hb321Gu/itawT7ykzU8uBUO3RwcIe75zF2Upt1TutXgAVDmQxwGJePlTY957j+WyZ8QBY4z3LL1/dn/3gL7725A29YcX1NUNqp/oZ5gw3+dkHFV1Y2srvbfPO2gb1Go5qj28AQT6m0Smz0E/Zhwen1+bxO8EW/YSaOwxgNq2vZpkKgHnaaTWXDXsMbpZ8Md8u6FYWSGjh0DqrBgqSGopt75E3EqdTTCqYPnbOfVBBu5dIAfMzqv7u3c69KaTLRQMFu/OxTbSdT/PmvGqJqXsqYBDjM0LPc8U5fSqsm8dBBx3q/mw1lGf5OwsieHwfimcprt05ypy09yiSVQturTFCl/5Ms7bHnrXOwntZ3Cj0/MxNxcAn0yuTU+JVr607aJZKFIYhkBr0iS7i5+qlwj9YDbHK//7V/ac3/PSa4fGJuMvSWmWtyzrjAklKcWNcsGVQf77GFe7IZX2UIQrM1zRWGTtVhEGgoyUlaIm+Tp0hDxplJUp6Ru/qIpYzgyAlryVSsm0LlAmLx6NHuIdfVdXR6rYxdsjrnLTn7Gel0nKkM3pwtmFqCidtK5dF7AArENtmtVzglFoNp2facux4VjfeOcE/oCeXg6ZpAE4Zw1FQh0Im2hXFovY7o4I+4/Ry+VS3vdeE2sD/1lbjQ3vYHf1YLmBhhIcTdeBu2HNPChXCVe6abbEHwQHqzs3V3zos0dlX/b7DHKcCL/tu3kJRxbna9s3d7uNQVayaAUvfF9+/fAlIzxKpXvpnhaEmjKEAEaMTyksN11UneTihExpX+rZIDXVoKHQ0Ts5UtAqt0wH37A7IrE13+MvNS1wosGTkRIu8M9KMLJT0k59zgDBgr9Bu/oADlG+PgGGm2U7u6/o1OhUDg8Bj/BDs0xtUJflVGUz79cU/fXWQ4+IJ4qGXeAjKbdcBtiIraSaaKtyTQNczO0+6UqV+CtEGoSGP9oH/la5L6ZyKyL2HK1zeHvkbAKLP1o1F/5xEfw0+f1Hhd3zwG/R5eD7CBspncwvMoj8a6HfJIFUPzpyAPL6UzbFx6PGdEiWTzYCZ3ibEAql4io577cKNMDUAyKQDjd6IG5kHq/a2F0WLwqZ4qaqeYansodJeDwkBD9fRaqhemq6EUxv6iJv2nXqVOKAlE3A4O20MUHMlmIpnC8jamAdQlz5INNILaK7pHsof4nH8qPKZWzsauXa4nX9fICpDiv2xGr1alQqiQ8ADbiXTOnhh0Hmzxlr7DQ76PmghT3/V+sK4fR6TBp/gPaVOOTY81ifA55Uq+ivXTrt4YH7MKzEMsAX0TvnL2PZnr+7ri/yryrFflNih2pFjh26goUJljcNgSkdBzRB5itl/K5NPkahE9pmRgIM7QrGyDCwCZ1E/ueGr6bZc3uO6vPr7IsVxRjmp0dmyWGE3aFTIe31EZQF+5DYAqwkhKMT0Ba4dMOomocFhF6htlnhlCaiQdogkrLZgG/4sHvPGdtdCnU36OoDJFwQlACjpHsEsRMdxSESWCYFeAtKy9Qpl99CMYk8VMZnrpMESlDYP4hFPWPAzLdQ9RL0dXkfIdle4HL0ifCHkUAGEkUBSQe3G2LAc9BjS3nhbIiPUF2RHIQY05RiVSp7Hgpu+HwQFIpjPnl1IIbIAkY+2uIPS8QQHagY9+UPk6Zd1DeWIvdxND02l1+FORPZtIBxR0KsnT7aQ/Ri/Yqy9Qzas/TYQeuOvBi3ebyQNr24Q9V+V5Pw/LUUqkE4E/NePJQjUD+6y0dUNIbZUGDY2/IEIDq0mzAOiAZYssNQtsCmiCRipIKRUtMY5XGKV0oe06NxUEPW8MfOvymBuUT04QUBQvhSvRyxJgFeY9W6HeIFbGpgTG54BWQOrRnU8JTQJTMkABNwFcmAQ0GiTBUvUop0SxhURNWEZd6hLFEYrmA/xeb5t0fUbB7DhaaijLVJJ0ee6F5AJ9ybcQUFUIzelP1DWbTuSSADCuXQXlB/u/kDJzgFRRr9GoBQxd+PpsNACyzr9CnUbZXQL3TAwowuhBbXrmaSw0TXEF5y2fTBJcTYNMuhCdSjUTzvWJZPWd7HD0wOFGrd42w6tgxgkQ0hd9FlBZnDZXpJwl1yifemrvoHZrcXYIQ5ca6Mh4pRpwky1Wtw1zJZvmeKNks/L02LYuZE6Eob6pgvhe0MCoHGk0BcSk3U2Ejo7VM9FUbeOn1D/FHOutRB9WADcOADFETU3BVsmx1Q+6O8+aeyCTCO3tPXdEguy6//cYn1enQoXhXQjJUI/BwQ7Inq3gfNBcybkceuUOKb5Uh/33DHiOrJEhwQj2PG3oJ6zwDVUEZQ4jwrqwp/0+eYRYkGf3hLUsp5qriTWgIlD4UTW0QEKtCsq93kRoFuQT00gmPArtBRRVUFA/BME2n1uflHOwYghRQFbI2vhBSrtHqgLgtTzbNV5AS7oO4mwKBqjS3R5UPHSK6WC1oBrUaeHSvh9qnaNNgHnjxwklQaDNo2DEAeUWb/QAX8nglFaCLPRAziRKSGKUKF0KASKuIUjVJ3ITtRI0dyUtiyiZEDOFh62bN5cVcLIXbEpYQBHpSNLWoQ+Uyjocjzp5rZSHhRk7SJ/WhCyQoVSSlZ4lP2RiwgxhOIhzqyo42+w+4anbfJfhGQ2XDPy0fWt4Qf9j4vyZEhkRAFw9TTpnnXGQvZ4uIGUcosRkdi3ioBfe+N4c/Y5OvsvVaT74w9Q2GngKQ2DjUZBE0PPsANFKyOBTIKnMqoKHb3IDoxT13YIGjxGKbjEahI7alF4HBojSqnQvJhNVOceGI2iK/DJTsYKNAXO724VWHRpwbpwDGCeSPmS0uMfBH7wSTlAcgKnL9ly4GYjWVKbCDGLaLqE8aHEzdyCn00zV3gdECTCXHjA02Ggx1EEscP1Ee4I0sbSCFBDRswUcAefOjX5YkXINjoN35wto4vRD3Rdv5a33DIIvCI6w6jfjkQ5w0bC2ABqeLRAIc+ZWoYJHEIAS4wXn4iRCak/dM2L1pMzbjRuBd47GhVPA+FRjADEpa2S4YHQIBotH9eBdj6a8qKsoboRpYk6tQhQwqfQFjfZmirEhkLUkI0XUCDIRaNTxZWbOsJu8s2GC4Jxyg0IPsMZvh+Lgz1YDRXSZlCgBt88UAoUonYfJJhRHOCEQ7RfVShKVmxFyaBeUIjnw+3g+P+7IP/slbTqPx5XI4tIQUD7mNaCbX7ARvaARB5xAw4wQGXBoeai6QxYRS/jbWl1yMYfNCuFlW9KFEaeKlEcJK7T3VMO7oLHzpNyQM9SJjVMDMWgqvnggIh3xH8iRIDMlZDxdDVyhuAHWAb73JNY5LBwPgGZUra5mLCcYnuzT967/THkWbCqTTFQBiEAhWPKQ+UBWmvA9nYFaircH33xMfQqHAQeqhoqJOlH7qF7WRjUIeIWR74F1A2Ns7C/svkdU6MBQJWbh05k/JHynVDKSTWK6kQeHBGUv3xKorAQxIiWxkLpV8wSN+/uqcoTJPobajYDaregeJ74Qlnp9WjgozEggYPzAYelSSpQ1ykRHi8Zyj/FXznejEBee6AGSFtHaVTk2SvnZ/2zRBLcDsAjxkOUOcbrodChQ0iWMGlCgUdDLUg3JVHtKyXUGGgwZ92HwBPUiNIDkUJRZYeEYB91v89yO93FpPzje5OHjmDKjYyuaB8upr284RE6owEzWe/b1rxFOcg+C/Yi0Vqn8bSg+yn6WYKf/DOgOWh+lBvoSb8hFcVUW9MlzY4ryEfWNHKNcJeQDc9+MWCwFZTbpA3lWPAjuPiLY0GpZ9kIhNABNZsKg5ThnAzljwyjaqhiYKBpjI5zH/JSBfmzQFq8FiugQvfrdSCUdsFEgXB4V83UUSHNIbttN8qZwlqa6sGOpMeQJ9T8aEpKFiJVxCG1hineESOxEVdJHgYXBcUMJ+VKC11RB+HDH44ACQ9NxqARwTfOinVXbVSh7UC1SyVT9ZXiop0+g1v3fYIb82Xpb2JPxYDXNCbJRUfKRoS31xVRF6VP+fYBYw8ed3KXZSU6WMGTc7iKKJdJEYzXlXWIqzexBUwwdVSIxK7EZT8LBxYGNwTAgWg0BFlDWMxJX+EvsWsrgC7WaHkKpINkYPxB/2tzeCP/Encbi3LHb3bijqqt0knelQpwbcS75cgT+9qj1L12FFICOXjTa9cJUOkVOJOQOwl7hy7mubTdkCpCi84nUNiDuQD+k7XVSA2IwTSWfNOQimF44w1PVTZwh0gp+gQlPdLsDkUZRf9vVLExqVN7qlyVb0rWTvySYI6yhZ3xzx3IK5EazQgNzfnaam1ep31VqUqJBml+qmji1rU/cwrtV0gX+lRwC4cimoJmDyyQu8E7b3aF4G2oEQAYsl4S28Igzd014lM8ALZJX3oB9P12yx24pUHbYV6VXpaUw0I03O7KNHQEXUEryWJ8IEYt8KzJB2HyIbiGFPyMgTSfzfpcxqFWDZiWuTlw26A91+3NYO+TN+QM4siETyxlEyJgSpK2WlgI9rLkKr1IwjFHmgZXgA0spKKotZbw+yjc8rm9OrXADwqa57L4+gZ0oDwOwoGfghgGFmaE0Y3TSXNJh0fWSrAX3jA8kWkKCJiNp0Ut4JS/xQg84YsJGPE7IGx4CN/dFW407S1Q4hcpVsp+823NEEIHTkgflMWltjKm7bkTWO/CIhCGsQ98mc3xbX1A8YIWctKMBk6H247EP/mm6S7Z1rYaOoqSjFJTWhuinIvSWCcUCNLDCdgYCQPqA2SE+4ZdD7qQQvxlwnU3zbYQQNKq8QbqEFb6tI5qPXMhYoIV1pGTTqcRhdU/NaShHloA2eXX1jGAIwUiyqQmSoRGkAu0Z0mFh3dNBItbfw+ykBFkhYdE3Y88dQYAwoiol+1pySHAh0qpi7dnRstV1k96sFkwdMefd0oSygE/ZKYxw6OphUrpG3RFy2BztGFl2syDnblm4eEhoARcNRASC0d3lCl1q/kbfLmkWGzK4lyodgzYZOlf1BLMStsjxQdPrL2INRMVtTB+LESyQ5t0Sbrgd1toyEkgPQ8kfCIIW4dsksYoNJYwTDNDcuGkDrrXAQqUxoGyExKi4BxALpg/DeT149go74+8pf/gU/KIdQcFwaM4UF+OAOsEjd9ywCgENDEd1TWGoXuPujbQyYYiTJE7ol0oM3QMXQe8YDeXBpzgEQiVYU8Mzc7B466pizeTBEIa6E3DHtxnROoPUAqYSVjos9YTZKCURjs7OxwT7jd2ah/WC9r+Jb9R24sF6lwlvs2arhbLECIUAepq4GpFPYUYR/n35eoW2/t8tcNACWBpEk6VJKMD8DhNDtHgBywVvQMt7qTq5pqmdWaShuRsDr2lwZdvrH8a1xqgYSJeBThA4ilKRfsvLPD6gWGlyZZ2aQbvGpTNXqCgdmoCHR5lj3BW5UyYUbP/MKqFRGecIuQAjsBWtGrIFBPwAPYQ8kb1ohOIruv4s+ppb7AMdkGWEYw5A+yJmEIweREGkcVEHrCJ5kiEXNnV8S4kc9XAtrusKQnhT6UF2gcdhx+zW1V4yDV64Gh7moLHrENREvBVgppYgfIdG0ob1wmM5Hq49dQMymOc7q3ICD4BktGIppMKUCqhK9FTPRPFSgcjFyEUzQJHJOfUUUtBM9RLv5cHIFyjfsg5CX3QC3ybjH92ICaV9nYiNBa+IO7QRjn6iD7aeDI+87a6+EQqnw/gSHEe8SIEir+a91gmHHFrI++Wz7772zftB14jJXILso6kCsmLGIc/uzQadl7CRc6QQv52+cnPbO4uvgDYs0du++V8L0nbW7BkgGc0eS7jaselYJXp0yCSKGmuDHA9fhmjIpOhiUwYfX9zahDSr0gosZ5kEvuAQMtRwwAAuGiOgrrFO6GbLn1/YTncg6yIDDalSl36JTVyoRXtPCApWCBPrtROnQSis2o2qdiB5cXv4mQBDLpyardIMkGnOhDoUPcQHR3K7eA97E2WdZiFt8Xi5e0llFi/Nmbyxjb6jGrBZAMBtAjaNFfAFjhD+iG/lvYOYIlR6YCA0PychAAYw+d0BLR+byJxuBqp3xUSuvwzZO+98eq+m6KsiRIAoq1eo7YAyU08zpqwpBAgC/onVqIcnj6gjmSZ8LE55ZPdoJIb3D00P0Nsa+KgQT9dlrCvRZlY2qhrJAu/iqKZPHjjgXR8kX5/7dvdUSqKIQjgdS8oBz8XoYGa+5j6vXQObuk0zJ0oS3jq6txLRziP83W4ZDuKHBTDUhK+GTR9GHhBOBDfBqln6i3epvSsgaYcUftgmn0q4mRDR9colkvWIPcuAKAvEQ1EALqgO3DZOmuCuAI/cwNnUz2EpQBOwL/B9YXvJg3dEGguItM+I43iNwros1lACct4bUw1Sirvrs1fLBFmbWHPNPEfnpqhPkkD8Opdi+8kDeoDlAXLVG33bVVqgHrViM8S2YLeDPttmDPEAczYfOo6ZkCC23H0WeBKZIAcnKaDNVa6RnELDoHWEZmQfRTph6id662Dh4gO5P6bHmPkZ4SygadBogHqAQCAcNpFeYij/QOcJIHfX6bdf5oWMOQnOoQVUZGf3Unsuqgha5MCMXK1m/zgYmh3FshPBKmhe9D/QJ/RfTy4dDJ6ftwFOuN5UXVOeyVdw/AEqwRNaXBQRfp4KnhFNDpR8wUGTmQTh7k1jJIu9gmmUOv60Rz8mjvqwSKyiyK2DbprcJLOkK0PKCEZVRh4J22iQCYNtXNo8aSxDhpb025Hody3G0ZjIIwWPNvkfFHZGwoAQi5GlEQ3HRKIF4DY0iwSKSbN8eJ5lsva5UUHPOymTIJ2LIFRQA0PSA1o8tMG4ZF+1TKo1aaMVXKk0zO4z9GTBlF4c6zNoI8Lep6O2KXpgHXWkYQ4NJY17dW0m3IEEIkvFtNAOFp7rAOoj+vK9LfjaE5ZuCCQhKTjRXDHFvbS3iGOGCPH/YAdI6sNOVpBK7qFkGJXUKq0CBI/NKm0La47XIHehVbxraXIsY/9ojAmLaCNykg9ZQCvJcyzPAVeV1YU/FITeZ3gO7MB8Mfr9FEYfvekGCB7F0WSTJNKEJp8ZGCKuh3yPIgWhB0aktBKKe6JeFCMbdMpSydvddrusjxQHQeHD0Ft8CARydE0iqCYlMuBoSrTBcKos4aP1WSqdOYN0aZNBG2jZc170Qvv9HCjUNqG3aPusbWPRU/EqmkNBLVIgXAZbaRtAbQzchr8sKbD3dp8uu0d9BuagfkWonY/awY9U4E0FV1zlAcmXjBOhWEth+bCUcMwTIhMNEXcN8YHwYgUPMTo+ZwiqGRl4BygPbIDdyVE5TV0PoPqRyV67AhAQWTeqRITCdB51E6cOi6kPTNSVHToD6QHe4/TfU1HdEjt1TCJOt/hAxsjZtkjNBhJzmBBkTjXeAiNtabRiDoGUDV4caf6Z5+t4QmBhX6010nTBIlq2hTWNAGarvPQmJKq2q7JGuJlbVjjBiItsiQcqlg1R9M+3tLhrC3imKIMZEQLoD4Xg2T1fymwmm6bboAGqAikIbwWLGh48bDv0B8aHNKjppPEiOqoEwcwU+9vA4u1IXr3IdJB/gqEjrInOEgowXQOxB+gGV+Bw6AqeXvXYdQ7d8Pu0HaIGI21uIjmQeHAN5SQ7qUUlOTQuqu//X/ROyIq4TgVAjxchxDA4aAFUzcIQctXSIK0S7dpRJh0rKsLIRFXgLOmw1yPJCC3NX7WFgetvSpNDBxoQKcDHlQNliSPaEOH2stBu8vExuywoPjkgqJXOdM3uy1KtAXDLPeO7IcqUl3YyBoWdJvBr26oLZRk0TmeQ/O06wTckDJ35NYNIarHi5SNDoVqCnV07phrbt6GekUiASIGVAdbErFig5W84yE2eZTsVGdDGJAhb2PB2gJElclwqhMJCSI9vOJkdeno8B7sBXphNdzDxTBGCTsixXUGj7Djc3iYJQszVW7UIrx/ilW1TtJ5HostIi90Mgcq2E67hCryUrQbg7rBiOmshjQTCiFpJkYO9VhEiEI5Gr1INmFd4AGygqaksjFuoYSDZjGk/p6INgBKU2KoEeURdCwvknABgmQnPolVd7y09u0T9Wua8dG09R2I4jZ96v93KOEd6wySyer4/NaaMFAKboSf5sKhx6jTiDRm4rkGIuLQGWrfd5IXl5EQN3kb7oEnHrLcwj2JTIhpHoC14qDpqylYM/QwXqlLQ6J2BGQw/zgoKvpPVADeaLhSawMuPOIIuCd+OpO6etVZaFqbdWMDvMbcy2mQatxkIGWFvV5nFjNcA7YDIF774vbNg1BDR4wUvCxGpFlQdlmeNTsdT+CCxHXDhXjRxoWG9m0wWGUd7r3fLPlBZNhvJ3Bql+4iOLGQpnaZxQVpDK9j6/QWvvtqblS0AbnlLMfSqQ7w+1AwTRtBlpNm3YRFU5d+Dh6HqnA67g80QPSap73TCmKmd0rF8CcNr8ttSRGUFNHRc+qwhtAXCWoNm68xvzxtE4qCj/KdOX9kHnX9Jfee3UdvrEjFdPgPWWZl6ghCA8jAVnQpDekSIqJpfoWGiWe1fPWMOiQS0Q6UN15F+QdQtsEWUDGND6sMHRHJVLba1h/9HyxcotI8cAQKQLwVO0LzjejxrphCHnB6ehrVABsGnbyLmNXHNVVj3aYW0dikawvjaBt6g3lqRWRwbxsIF+V/ZrSSbzpUSLkYUM1SuraMdZ8ekyPsdCYijMrPQmZkFLwy0WsLcYreqJoADQqdUKeJQESNewR4uTrvg3g5ByOFiODGOk/ZWAsum9TxwT4Qq9zSjv4HH9SvVyfhqjQ5Q/NUMYeBR1BReVM0N+juv36cHwIdiF04a3rFEr/19tFCRGj1gH+qCR8W5WSjzp6N+HdPoLpf/oB8bJyY+z8aqL9AcJwzPwAAAYRpQ0NQSUNDIHByb2ZpbGUAAHicfZE9SMNAHMVfU0XRioIdRBwyVCcLokUctQpFqBBqhVYdTC79giYNSYqLo+BacPBjserg4qyrg6sgCH6AuLo4KbpIif9LCi1iPDjux7t7j7t3gFAvM83qmAA03TZTibiYya6KXa8IohcDiCImM8uYk6QkfMfXPQJ8vYvyLP9zf44+NWcxICASzzLDtIk3iKc3bYPzPnGYFWWV+Jx43KQLEj9yXfH4jXPBZYFnhs10ap44TCwW2lhpY1Y0NeIYcUTVdMoXMh6rnLc4a+Uqa96TvzCU01eWuU5zBAksYgkSRCioooQybOqrBJ0UCynaj/v4h12/RC6FXCUwciygAg2y6wf/g9/dWvmpSS8pFAc6XxznYxTo2gUaNcf5PnacxgkQfAau9Ja/UgdmPkmvtbTIEdC/DVxctzRlD7jcAYaeDNmUXSlIU8jngfcz+qYsMHgL9Kx5vTX3cfoApKmr5A1wcAiMFSh73efd3e29/Xum2d8Prqtyvx5B69QAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfnAwsQLgE3EuaBAAAbGUlEQVR42u2de3Bc133fP+fcx74XizewBAiQICm+rRdF0pJsSdHDlWI7rqNYmU46mdZ12rRu7KZN2kwnncYzmWkysVOPM572nzR1nbhW7YkT15atRxVblEhKNB8iRRMgCRIg3lhgse/d+zj9Y+8udxcL8AVKiojfzA4G9969e+75nt/v/H7f8zu/K7hz5XvAJ/bs3s3g4CAAf/v97wPsBM6+V43S7lAwfrxr27aHd2zf7uvo7ERKCcDgwADFUumpVCo1DFx4Lxqm36GAbF1IJiOtnZ2ULIvx8XGEELTHYljF4hagZV1D3l35QsmyYt09PQjgrWPHSCwsYGgand3dhMJhtbCwMA9cercbJu9QQH4oYKryj1IKpRQjo6O0t7fjM81fAR59Lxp2JwDSBWwHBmqO/Yll22dRqnrAcRxc133PG3snAPK7ntf07Zpjr/hM8zEhRP2Eqr/3U+oHfVJ/4eCBA091dHSQz+cfeOnll/NAABjMFwrfc5X6uHfdKeAe27addUDWXsLAEcABNu0b6iMUDPHysbcJBYO+bC53EhB+n29AXtWQbcAJTdPWNWSNZbsQ4kt+n29n5cC50TF8psHM7CxSSiGl3CuEYPeePUSjUYQQHNi/33/4yJE9O7durcYk64DcutynSfnPdV3/5dq54O9+dgqUwjCM6jEhBOFwGNM0AYhGowBYloWqmejXAbl+8QHPALW99zEFn5VSYtt29aDrOCggEgjQ091NMpFgYWkJ0dgRuk6uUAAgEomwZcuW7efPn9/vmb91QJpINxD1/Nj2VvhO5UR0yyb8kfCyL8wupckUSgDEYjEGBwaYM02KllUGSikqnlbA72djXx9SSmKxGJZtPw7MrQOysvwh8E8ATOAXatRj8KMP0tq/ARrMzYnRK4wvpJbdyLZtkvPzGLpOIBRCCIEQgtbOTgBGR0c5febM14D/tG6ymssbnzKM/V1KIWwb0WCrLv3Pb1H45NP07tpe96VafGzLYnFujjPDwxSKRd45f577olFKts1rhw6953PH36fA8OizhrG33XWFdJxltr88G9skjp9i4tSZFW/iuC5jExNkc7kqVVKdZ94HEfrfB0A6gf/1acO4r8V1g4brLjNJdZhcuERhMVl3bHN3O/1tLVW+Kp3N4rpuU21QSjE+Pl7nEKx7WfUSAv5Rh1LIa4CxkrSEAvikIrm4uOr3hRAYhkEhk3nPTdf73mQJ274pMCpSzOeZnZnBtqzVAdF1TNMkmM2yO97NJz764buAfeuA3I6gJRAgGA4vA6HWXBVLJc6MjNBy6BD3bxlgqL/vM8C/XzdZt0GWkkmE61LREUcITMOgke19P8gHHpBu4B/fv5f2wY38/CtfrwQinLJt3PeJq3vHADIyOUtyYhbfzBSZ8Yk6l3k7kAGmPZPleBQL61zW7ZNMoUQhX0BevoLtBZQVGfiVX2JRN5ken6rOI1LTwHHWAbmdUoxEcLZvx83nMTxWt5RMotk2C/kii4uLdZP7usm6zZIPh7FMk1KxSCgSAWBB03j9jWOMT001Rodku7rILKXJZTLrgNwuMUwTw1v7qPF7EULUaYWUkksbNhB+Z5ilTJrurq7gzOxsHJhcB2QNRKFQsIz/cl2FlBLDMCiVStXjjuPQ2tnJ1t1byRVLJE4Pf2xmdvYnwJb1wHAN5J5NfeyMdzaABM898RAHd2+r8lZSSiLhML/4zDOYpsnhkTGOnL3AwuwswLvKPH6gARFCkM+kmZ2bq39oIRAIpJRIKent6eHAgQOcOXMGy7KYnJpic0cLTz94P3t37OgH3uJdyvL8wFMnhs9PJBxeOXDs6KCzrQ27WKSvrw9N08jn81wYG2Nseo72zk4/cN+6hqyBJFIZspZNIBC4qjXA5MISi9kcAD6fD79pks9m8Zlmdb558fAx5haT7LtrM//yuU8RDfh/G9izDsgtyNh8ksnkcvf19JUZxhJLywPJZLKOTulqCbMl3sXd27cB/Bdg/x0PiLoWASjE1c9N/cDyYNAwDLq6unARlGybkmWzY2iQu7cNtQKxO9rtVT4flEqwwjKraxjgJbcpKZfFFqvJsqVbpUAp+vr66OvrIwO8cOIcLvDZX/4kR06d+aMTwxf6gN+6o02Wa5qoJmmers9XBUM4DpnXDnP6L5+/Jq2+ODdHOpnE9dbZj506xbFTp+iMx9EaEq6FEGhC8IPjZzk+euW2u8HvZ0CmgP1HSyWroBRK16+CIgSuaVbNlLBthG2jShbW+AQjL72Ks8rauFIK4XW2qxSWbWM7zqpmz3ZcHFcBPAd89U40WUXg6AnX/VzUtn8/tGHDJqEUxZkZVIUq90xOpXMRAooW6rUjzLe1MbawRCKbrx/xQCaVIl8somsaVgU4pcikUgTDYaSUZDIZkktLoBSuKkf2iUQC4DTwwzuZOvkfP3Gc2Gb4rO26u6YBWyloogGVhDek5NALL9eNeCnEsv0fumGglML2AJ6emmJw82ZyuRzJxUWy6TSO43Dh8mUi4TCFYnEdEE/+9OLYmASeWuWa/lgstqO7q4uR8+eXpfO0tLSwIR4HIZiZnqZUKqFrGhhG2VwBaS/rZG5ujlI+T1sshuM4FAoFdMMglUqxuEqyxJ0ECMCXvc9K8psdHR1/tmXLFs4NDy872d7WxtDQUDneSKerpGII6PQ0aVNXFxG/D5+uUaEcNU2jf8OGqpYtplLrgNyoBAMB8oXCiu6v7Tg4rosmJbs1je0+X9nknTzJric/gt8tcuSd8yjPNdbexT0jd+ou3KseV83HNX3eujqMT04y1NPOrz7x8Lu6zH5HFg7QpEQKUd6g47rgudOj27ay9PbPuTB+Bdd1mRu5wOhSitHxMTZv3LiuIWspyaUlpiYneWCon6ENvUQjEVylmLZtRiyLEcsiZZpcmk0wkyzPE+GuTto2DzI7Pw/AEwfu5XOf/vjjwBfXAblFWVhYYHz0Aj2tUaKhEIam4ToOw0rxiuPwSpNsE+W6SMfhCSCeSrGxrZVYNLIbeHrdZF0PxeI4WDVLss0m88VUGsu2cV0X23EIB4O0xmIEwmFMvx+AtvZ2DNNk9sJlRn52inh3N5qUZNMZcsodA46vA3Idks9kSM7Pr7iTNpHK8N1XD9e7w62tbOzvJ9bRcTVmaWsjl80yNz3Ni67Lpniczg0bOHZ6mJOnTn0H+J11QK5DQtEo7T09uOfOLTs3ODDAjh07WJyd5eLlyyRTKbZt3oxhGJx4+21Mv58PHzxYvT4QDNK/aRN9g4NVsrKvr49AIPAbh48c6QeeXQfkWoAkEvToOp9UCmq2QQPIdBpzdJSuhQWefvbj6KaJEJKZRII/PXcOslnODQ+zedMmDC8Ru5E19tbgg9zGNZEPFCB6KoVZKGCWe6/+ZC4Hly8jCwXaW1ow/D5mEgtMzFxNgBgeHsbv89Hd3Y3fm0/e9Wf4AOHxjg1/O+s4H288ERCCSGURC8H41DTSNDk/Ns7zL75ad+2pt9/mo62t64Csgbx60nWTJ123vfHEw5rWtbGS7GYa/OAb32ZslfC7UCgQCATqqj+sA3JzcgJ4sPHgTx3n13Cc/0a5EtA15cjRozywbx/d3d3v+gPcKYHhN4CHb5TjWjdZt5nCutYF+z70IQCibW34A6sq08M0T8D+BuWCaTct4gMOwh9yNeswChxodlEsEmGgv5+AN5G3tLdj+nzYlrVsW4KQErlC5bl0JjP+5ptvPg/89loB8gTwDxqOfQUYv00d1n2rI2pVeyzlP6Sm1uJKFRvCwSDxnp6rXlkoRDgcRpeSYr5+Td4wTfyhUFMNKhaLLC4uTrz51lvfAP7DrZqsRzd0d/8LhPjUbHkxHwDHcbKu6166HR0mhOgVQjRlThvLX9zEveuCO+UlKjT1qopFpsqZ7mUNiURQtk2wSafncjkKxSKtbW0A+Pz+6tq9z+cj2tKyAfhXtwrIXk3K3zNN83G/30+yZpmy4Lr/sTFiXcutX6tVcHO8EkqrdfqKE0ZDHlezyLtyvLENbbFYFQylFJZlVTs9k82Sy+dxHYdgKITp9yMoFz9zHAfLsti8ebN28eLFfcBJoHQzgHzTNM3d03NzV9Niahrc+HBrUQ+k2X2bdepqv7UWNRKllJgN8UbtELAdh5FLyw2EoxT3339/ZYQyNzfH8PAw8Xic7XfdFbh48eJRIE5NfeDb5mVV0mmajeC1LrV6I/eTUuLztq4VisVq23RNqwvyas81k9GxMfp6e/GZJhcuX75mJuTSwgIpb/PoxMQEY2Nj1WnrluIQXdfrRovjONi2XW28UgrbtqujVtO092U1BACfaa5oDn2muWrighCC2fl5rkxN1T2fZdsUikVKjalAQlS9owbNP+45RL9x8xpSm1xWyZutpGw2MTNSyuoE3KwDlFI3VI+qco/a70gviXolqZRccl0Xt3blTwhc16XkuuVBJAQBv7/uXq7rVlOCzJqNoY2mu1Qq4XrP6bouTsMKYyQSASGYmp2t7aderw++4LpuiNXTmOoB+cyTj5IrFvjBa0cxPDNR26hGr6e2XmHlXO2xWjBuxAmoAHEj36lkvLuuW2cjattXOV4slTANg77eXlpaW8teUhMnIZlMcnF09Kq1qBkgyksvrXOHG6xLQ1+dB965IQ0ZiPeQzuVwXZdmXlWzjq1oh/DSNDUpidfwP75gENM0UcCpU6cA2LZ1a92OpmayLCATgmAoRKFY5PJV+wzA1i1bMH0+UArHtsmm003vadk2V6amKJVK5VdTdHTQ1taG4eVkQbmUU8VCFPL563ZeTJ8P13EIBINs2bIFpRQnTp4E+N9A3vv7wo2bLKWW28catKPRKO3t9WRqOpUinclgGgamYdBVsxQajESqI7ACSG88TtTbwK+8TqyMwIrZc2ybTLK+OlwoGiWXz5NNp1FKkUgmUUox2N5edVGlFOhG2eRdmJjGqqkcblkWV7xCAcViEc0wcJTC8UrDKiAxM1O9PrUCsJVoWilFoVDA7/cTCIVACPzBIIFQCNd1K4B88Wa9LEsp5bpKydXsery3ly1b6rdsT05OMjIy0pSQy6XT5LwOrAW98r/jOJWtx4xPTpJIJhmIx2mNxZaZkawXGw329+O4LoupFK7j0Hb4MGFNQ2kaLQfvZ+vBgwghODvyPCeGL1o1no4EqjbljcOHrzmXreQUSCkpFYscOnSIRx55BE3TCASDjQP4pmKDWtv0Vwj5XCjgp7hC5kbjBO0zTXRdrzNxjuuye9u26sOkMxnONMm1vV7Zf889q07oCpj3XM6De3bwkXt2I4Tgz/7yeU4MX3wceNm79D7K25uv27loBMQ0DDRNqw4oIQSO43Dw4EGCHiC5fJ6XX345S7kG/S1RJ58XqCu5fP7fVv33ZruJarwsTdPKebKexyE8+uDSlStVpG3HIRwKVRu7FhVApaaVa+x67Wzr6iqD70pe//koD+3Y3Izh1W4FDL/PhxCC7o4OWltacF2Xcxcv1vXH0tIS54aH3wQ+vRb0+7xSaknTtKr7Z10j9d7yYpSqSfJGct6zy41mx+/z0dfbS7FY5PLExLIH/qefeoaejjJHVLJsfnruEheHh5d5NJqmsZBOMzQ0hBSiGky5wEI2x0tvvMnUXALgD4DPV0jdmwWj8gy9XV1EwmE0TUNKydDAAK2dnfg8x8BxHGZmZoq3QsbqzX5Y91C/FiCNo11528OMGs1yvBjAZ5plW+v3EwoEqlS3An7xoX0IIN7VSThYnqALJQupRolv3Mi9g3GCvvIgWUyl+fPv/RDXdQkFg3R2dtZF4a6C0cUMv/rMk+iadl3bmLP5Al//9l9z4MCBOjuey+UYrjG3pmlWn014MU04HGZ7bydBn4Ed7+CejT2DX/vWd/8A+P21AOQUSr1q2fYj14oFGu16KBCgtaWFcS+61aQkFo3iui6TMzNIKatA+3y+6qhSQDQcAgTpXJ6lTLm2bsmymJmaor272wPRj5QSq+bVRKVSaVkbhRB0dnYRa21D165vQdTw5Rns68PQdaLRaFVDCoVC3XOGAoFqrKGUIp/NMtTZSn9nKwGzfHwh6O/zvKs1AeRvbMdJ2Y4TWa39wF7TMMALyJRSBPx+Yh4glmWBYdTR14VCgVCNJ1LrVfzwjeNVlU+mUkzPzaGUolQqMTY5yfHjxxns6yMUDNaZw3g8TuPbECpyZOTydXeCY9u0xWL89LXXeOrJJ6sm2+/309/fv6KDUyqVuKuvuzrQ1oS7a3LsVeD+Vb7TC0yaponwUvptx2F+cZH5xcXqiLIsi/HJyRuKuBeSSeYWFqojvaJFK3lZi+WXtNxyJ1iWxWnPNF1veyvF+9d678hNP02lkwzDIOD3Vz+Nk37pBvbkdba301ezcleNxgcHm2rXWolhGNy7ezcAielpSg1OyYr0v5T86z/+GonkUmMcIdZSQ64ls8BgNpc7E/D7Q83cw6Jn213Xrdp7TdMoWRYXL1+uuoqhQKC6f682rqjMIRW5PDFBvLu76QreWsr9e/eW23adDLZSiicefYTXz4xQyGXI5/I4rvMWt5D3ezOAOMBl13VVM/WuNS+1cUuFAMx4byeoxCVSyrp4p1AslreY1dw7XyiQWFwknclg2TZ+v5/CdY7iZhJtbUXUDCTXcUgnk+i6TqS1Fb1Jglw6mSSdzSKEIBQIlIuexWJMTEyQTqVYWlpiKZ3Gdd3NwH9d4afPc40EiJUAaQP+HSunJ7mU36uyYmyymu2vvXY2kaijvZu51iXLIrG4eHXkeoTmQjJJLBq9oUWsxaUlnAY633VdMktls2M3LOlKKQkFAhRyOezyPnWK3rNJTcMplejo7KSnt7e27z7RlDS17am3jh0reibtj4GF1aiTivRtgmcH4MuHhEBp2ooG0fQWgWoplZXmjIqmqBrWWNSs8AFsdxzCSmG1trLU3k5maalOU4QQ6IZRJvO80RLQdeQNLJLNJRIsJJPVvelVM+k4TZeEQ4EAg008LeGRiQoIesHitRyHxcVFTv7sZ+xXisuu+28uKfU8cGU1DeneCs92wpd3AkkpmTIMMqt4Mq5XFXolqrqSXFDrv6sVRsMmy6LdtimFQiS6uphuojk+v5+ol/EB5TIZdg33pqDu/2aOg+M4y9Z6HMdB13V8njmqdpCuL69o6g2mcMu1XyrtOg6245BMJhl56y12BALssCwmXffLwOi1APlnXfClvd6DHXQc3iiVOH0Ly7S6R8VUNMiy7avclxD4Pde2dnyZ58/TMTPD9Nat17x/2CuOXNu581OrM949HvfV1FZ3dS2rCHQrkkmlmJiY4PylS+yVkgccBylFhXqWFvVvcGrUs4c3wmO1KcZXpGT2JgHRDYMdO3awe88eTp8+XY6sG+YW27bRdJ1P53JEa8yIVioRn5pipqenrohZZRQDzE9Pk02lqjR/Ln21AHJHTw+O46xaFaiZ5LNZDMNYM1CKhQK5XI5sPk+HZTEQ8HPP7/4WLckUzM59ZlwpG/hJMw35ylPwa/1r6EY+6rrs7e8hvnMLnd8vD4Wzus5xjwWueAefyeUwm7DAtxJznT17llgkUserNUowEsHfJL5Zq7d9LiUSyzahutkcf/HX/5eFC6Ps0DSelPILP7btdo9uqQOkR4P2RodPGAbSiycaXdTV3oxp6DqmEBQujzFjW1RCxq22jSEEr1PO8dznOPhWCXeHpqeZ6Owk52lGMHx9ywyRYLAus0Q3DEIN5k3T9RvO7SoVi9X0UqUUkViMfDbbVBOtGq5N1zSkz4eUgic//ADfzebQz4+iK9UO9DSarM8/Ds90SNnpSsmcUlTIrAnTZK6SVeK9GkgKUa59K8SymKEiD0pJhxDI2XkK50cRngaYSuF0dpJraSGQyXCXlNVzTT25TAbDNJGxGFokgmGaVWLP8tzQ2g4ORSKYfj/Kdeuchoqb6g8Gy0Do+k1pglUqkUunsS0Lx7YJRiLVvAKpaUhNQ0hJviYnoJIdGUin6TdNtj7+CO+cv0hmehZ/eWDKi2UsjlZa9Lk22GkIwaQQnL3OxmmaVka+yYP5XBc7EqHY0lJ+j9RVe4DQ9bKmCYFqMCnBfXcTeuxhMlf9elrGx4kaRtXbUUqRTaWWDQSlFJbjYDlOdfHKME38wSCGl4hwK2Jb1rJ3WZUKBQzTJBAK1X1qSS6/z0c4GCyX8bBtlmZmKeXy/NTzNHuF2Pmgpv0O8JwO7NkFfh2Ydxx+TPld1nU2VQjUCrmxmqZV6Y5aecl1eWiwn34pwassXWppwbZtUnNzXHJdtjW5X2zrEFpHB28mUgwVCvi85VmtVEKzbZxV5oRCocD50VF0TaOvt7ecJurz4Q+FblgbXNctd2CN9gUkhEM+CoZkcq4c0yVmZ2lpb6+L7pVSlBreV2I7DsIwyOULXPj6n6MDu73oumXjBvZ2tPcdOnbyr3Tg1D7Ke71SK7CNemVE36A8sOsu2nWNS4ffBCEYHRjgQiLBRE12R7OZXAFFTePMpk3ck0ohHIfI0aPIe+9lMR5f2bwZBps3bqzLx8qW6QzCLS11HXQth6GQz5Ndukoadsbj3L11Ez2tUeYXk/zeV//7Tfkc54FfB3F37SDcs4vW7Vvh2MmyD/zrNN985/r9HHYcRq4x+dle1vcy0st1eUQItvn9TD72GMePH2d6erqqWVt1nQcdB9nAS2V6erjS3c32cirN1ZW9JoAsLSzUsbMhv4/nnvwIKMWPDh3h/7z0dwA8/dB+fukXPlq97pUjb/GtF165Wev1EuW9NDfLH9Z11q5du4jH47z44otlL+vQCqSWKhaZBApeGuZqrGcjRWIaBlJKRoBZIUidOFEpIomuaei6zowQvKZpPOTzIUulqt0NJhIM5XLLg6yLFzneoF3FQqHOwzF0jW8Wcyggly981ns8pucTe775/R99+yphWfxN4P/dZKdmb2Eqcii/AutFoH9oYID2Gu0VTbT3KPBHN/ljISHEX1TWCmpBrM2FbczV3a8Uosl7bpVnZwWgNI1J4G8c5yTwpetsz2vATA3p92jNude5wSS2NZaPAf+5PRZ7IFZOaR1/5+zZL+pSysYJuQXoW4VCXk38SqnNgGuv4tE0Jiofan5ZDPhi1APE6Okh6bowNTVDzbvUb0AWbvJ7t0teAFoSyeRdiXKW5hzwHTRNq61ypzyy66vvgwYP1rZraONGNdjfr4Af8QGX0w2f9wMYEW/SrAIipVThYFC1xWKHgLtYl3dVPtGgtUpKqbZu2qQ+tHOnovw+yA+k/H9oahs4dZUIOwAAAABJRU5ErkJggg=="
+      }
+   },
+   "general" : {
+      "capabilities" : [ "milling" ],
+      "description" : "3-Axis DIY Desktop CNC Mill with standard dimensions:\nX=0 to 335mm\nY=0 to 208mm\nZ=0 to -60mm\n",
+      "minimumRevision" : 45805,
+      "model" : "Milo V1.5 - Standard",
+      "vendor" : "Millennium Machines"
+   },
+   "interactions" : {
+      "default" : {
+         "pairs" : [
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "head",
+                     "type" : "tool"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "X",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : [ "check_collisions" ],
+               "solids" : [
+                  {
+                     "id" : "Y",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "stock"
+                  }
+               ]
+            },
+            {
+               "setting" : null,
+               "solids" : [
+                  {
+                     "id" : "Z",
+                     "type" : "machine_part"
+                  },
+                  {
+                     "id" : "table",
+                     "type" : "fixture"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   "kinematics" : {
+      "default" : {
+         "conventions" : {
+            "rotation" : "right-handed"
+         },
+         "parts" : [
+            {
+               "control" : "driven",
+               "direction" : [ -1, -0, -0 ],
+               "id" : "X",
+               "max" : 335,
+               "min" : 0,
+               "name" : "X",
+               "parts" : [
+                  {
+                     "control" : "driven",
+                     "direction" : [ 0, -1, 0 ],
+                     "home" : 208,
+                     "id" : "Y",
+                     "max" : 208,
+                     "min" : 0,
+                     "name" : "Y",
+                     "parts" : [
+                        {
+                           "control" : "driven",
+                           "direction" : [ -0, -0, -1 ],
+                           "id" : "Z",
+                           "max" : 0,
+                           "min" : -60,
+                           "name" : "Z",
+                           "parts" : [
+                              {
+                                 "attach_frame" : {
+                                    "point" : [ 0, 0, 0 ],
+                                    "x_direction" : [ 1, 0, 0 ],
+                                    "z_direction" : [ 0, 0, 1 ]
+                                 },
+                                 "display_name" : "Table",
+                                 "id" : "table",
+                                 "type" : "table"
+                              }
+                           ],
+                           "type" : "linear"
+                        }
+                     ],
+                     "type" : "linear"
+                  }
+               ],
+               "type" : "linear"
+            },
+            {
+               "attach_frame" : {
+                  "point" : [ 0, 0, 0 ],
+                  "x_direction" : [ 1, -0, 0 ],
+                  "z_direction" : [ 0, 0, 1 ]
+               },
+               "display_name" : "Spindle",
+               "id" : "head",
+               "spindle" : {
+                  "max_speed" : 24000,
+                  "min_speed" : 8000
+               },
+               "tool_station" : {
+                  "coolants" : null,
+                  "max_tool_diameter" : 80,
+                  "max_tool_length" : 100
+               },
+               "type" : "head"
+            }
+         ],
+         "units" : {
+            "angle" : "degrees",
+            "length" : "mm"
+         }
+      }
+   },
+   "machining" : {
+      "default" : {
+         "feedrate_ratio" : 1,
+         "tool_change_time" : 120
+      }
+   },
+   "post" : {
+      "default" : {
+         "path" : "user://millennium-os-%%MOS_VERSION%%-post-f360.cps",
+         "properties" : {
+            "jobHomeBeforeStart" : true
+         }
+      }
+   },
+   "tooling" : {
+      "default" : {
+         "has_tool_changer" : false,
+         "number_of_tools" : 50,
+         "supports_tool_preload" : false
+      }
+   }
+}
+


### PR DESCRIPTION
Annoyingly, Fusion360 won't show operation properties unless the post-processor has been assigned to a machine. So here we add 2 machine definitions, one for the standard dimensions, and one for the extended Z used by the kits with FMJ and 120mm clearance.

We also slightly modify the output of the post-processor to make it easier to read, and add comments on more lines. Finally, we clean up some markdownlint issues in the post-processor readme.