### PR TITLE
Fix machine limit error if moving too close to ref surface during G8000

### DIFF
--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -34,14 +34,6 @@ if { global.mosPTID != state.currentTool }
 
 var safeZ = { move.axes[2].machinePosition }
 
-; Above the corner to be probed
-; J = start position X
-; K = start position Y
-; L = start position Z - our probe height
-var sX   = { param.J }
-var sY   = { param.K }
-var sZ   = { param.L }
-
 ; We do not apply tool radius to overtravel, because we need overtravel for
 ; Z probes as well as X/Y. Tool radius only applies for X/Y probes.
 var overtravel = { exists(param.O) ? param.O : global.mosOT }
@@ -50,9 +42,9 @@ var overtravel = { exists(param.O) ? param.O : global.mosOT }
 var tR = { ((state.currentTool <= limits.tools-1 && state.currentTool >= 0) ? global.mosTT[state.currentTool][0] : 0) }
 
 ; Set target positions
-var tPX = { var.sX }
-var tPY = { var.sY }
-var tPZ = { var.sZ }
+var tPX = { param.J }
+var tPY = { param.K }
+var tPZ = { param.L }
 
 var probeAxis = { param.H }
 var probeDist = { param.I }
@@ -74,7 +66,7 @@ else
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
 ; Run probing operation
-G6512 I{var.probeId} J{var.sX} K{var.sY} L{var.sZ} X{var.tPX} Y{var.tPY} Z{var.tPZ}
+G6512 I{var.probeId} J{param.J} K{param.K} L{param.L} X{var.tPX} Y{var.tPY} Z{var.tPZ}
 
 var sAxis = { (var.probeAxis <= 1)? "X" : (var.probeAxis <= 3)? "Y" : "Z" }
 

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -290,7 +290,7 @@ if { var.wizFeatureToolSetter }
         ; Disable the touch probe feature temporarily so we force a manual probe.
         set global.mosFeatTouchProbe = false
 
-        M291 P{"Please jog the <b>datum tool</b> less than 20mm over the reference surface, but not touching, then press <b>OK</b>."} R"MillenniumOS: Configuration Wizard" X1 Y1 Z1 S3
+        M291 P{"Please jog the <b>datum tool</b> just less than 20mm over the reference surface, but not touching, then press <b>OK</b>."} R"MillenniumOS: Configuration Wizard" X1 Y1 Z1 S3
         if { result != 0 }
             abort { "MillenniumOS: Operator aborted touch probe calibration!" }
 
@@ -300,7 +300,8 @@ if { var.wizFeatureToolSetter }
         if { var.wizTutorialMode }
             M291 P{"Using the following probing interface, please move the <b>datum tool</b> until it is just touching the reference surface, then press <b>Finish</b>."} R"MillenniumOS: Configuration Wizard" S2 T0
 
-        G6510.1 R0 W{null} H4 I20 O2 J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition} Z{move.axes[2].machinePosition - 20}
+        ; Distance to move towards target is the lower of (min Z - current Z) or 20mm.
+        G6510.1 R0 W{null} H4 I{min(abs(move.axes[2].min - move.axes[2].machinePosition), 20)} O0 J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}
 
         if { global.mosWPSfcPos == null || global.mosWPSfcAxis != "Z" }
             abort { "MillenniumOS: Failed to probe the reference surface!" }


### PR DESCRIPTION
Fixes #28 by using the lower of abs(minimum z pos - current z pos) or 20mm as the probing distance, so this should always be within the Z limits of the machine

We also remove the overtravel value as this would still allow us to trigger an out of limits message in certain situations.

This way, we should always be able to move to _at least_ the axis minimum if the machine position is within 20mm of it.

We also remove some unnecessary variables in `G6510.1`, falling back to using the `param.J`, `param.K` and `param.L` values directly as they are only used once and not calculated.