### PR TITLE
Smooth VSSC

### DIFF
--- a/macro/machine/M7000.g
+++ b/macro/machine/M7000.g
@@ -6,10 +6,10 @@
 
 
 if { !exists(param.P) }
-    abort { "Must specify period (P..) in milliseconds between spindle speed adjustments" }
+    abort { "Must specify period (P..) in milliseconds to complete a speed adjustment cycle" }
 
 if { !exists(param.V) }
-    abort { "Must specify variance (V..) in rpm of spindle speed adjustments" }
+    abort { "Must specify variance (V..) in rpm of spindle speed adjustment" }
 
 if { param.P < global.mosDAEUR }
     abort { "Period cannot be less than daemonUpdateRate (" ^ global.mosDAEUR ^ "ms)" }
@@ -17,10 +17,9 @@ if { param.P < global.mosDAEUR }
 if { mod(param.P, global.mosDAEUR) > 0 }
     abort { "Period must be a multiple of daemonUpdateRate (" ^ global.mosDAEUR ^ ")ms" }
 
-set global.mosVSP             = param.P
+set global.mosVSP           = param.P
 set global.mosVSV           = param.V
-set global.mosVSEnabled            = true
-set global.mosVSSW = false
+set global.mosVSEnabled     = true
 
 if { global.mosDebug }
     echo {"[VSSC] State: Enabled Period: " ^ param.P ^ "ms Variance: " ^ param.V ^ "RPM" }

--- a/macro/machine/M7001.g
+++ b/macro/machine/M7001.g
@@ -22,4 +22,3 @@ else
 ; Update adjustment time, RPM and direction
 set global.mosVSPT = 0
 set global.mosVSPS = 0
-set global.mosVSPD = true

--- a/macro/movement/G37.g
+++ b/macro/movement/G37.g
@@ -69,6 +69,11 @@ G10 P{state.currentTool} Z0
 
 echo {"Probing tool #" ^ state.currentTool ^ " length at X=" ^ global.mosTSP[0] ^ ", Y=" ^ global.mosTSP[1] }
 
+; TODO: Should we probe towards global.mosTSP[2] minus a static value
+; rather than the axis minimum? Right now, if we miss the toolsetter
+; due to a homing issue or missing steps, there's a high chance we
+; will plunge the tool into the table.
+
 ; Probe towards axis minimum until toolsetter is activated
 G6512 I{global.mosTSID} J{global.mosTSP[0]} K{global.mosTSP[1]} L{move.axes[2].max} Z{move.axes[2].min}
 

--- a/macro/private/run-vssc.g
+++ b/macro/private/run-vssc.g
@@ -14,70 +14,47 @@ if { !exists(global.mosLdd) || !global.mosLdd }
 ; speed variance, and then implement the new variance
 ; if the correct time has passed.
 
-; If tool is not active, dont bother calculating anything
-if { spindles[global.mosSID].state != "forward" }
-    M99 ; Return, spindle is not active
+; If spindle is not active or speed is zero, return
+if { spindles[global.mosSID].state != "forward" || spindles[global.mosSID].active == 0 }
+    M99 ; Return, spindle is not active or stationary
 
 ; Use uptime to get millisecond precision
 var curTime  = { mod(state.upTime, 1000000) * 1000 + state.msUpTime }
 
 ; Calculate time elapsed since previous VSSC speed adjustment
-var elapsedTime = var.curTime - global.mosVSPT
+var elapsedTime = { var.curTime - global.mosVSPT }
 
 ; This deals with time rollovers if machine is on for more than ~24 days
 ; see https://forum.duet3d.com/topic/27608/time-measurements/8
 if { var.elapsedTime < 0 }
   set var.elapsedTime = var.elapsedTime + 1000000 * 1000
 
-; Check if we need to adjust the spindle speed
-if { var.elapsedTime < global.mosVSP }
-    M99 ; return, not enough time passed for adjustment
+; The lower limit is the previously stored speed minus
+; half the configured variance, or the maximum spindle speed
+; minus half the variance, whichever is lower - as we
+; don't want to exceed the maximum spindle speed.
+var lowerLimit = { min((spindles[global.mosSID].max - global.mosVSV/2), global.mosVSPS - global.mosVSV/2) }
 
-; If spindle speed is zero, return
-if { spindles[global.mosSID].active == 0 }
-    M99 ; return, spindle is off
+; But it also needs to be higher than the minimum spindle speed.
+set var.lowerLimit = { max(var.lowerLimit, spindles[global.mosSID].min) }
 
-; Calculate the upper and lower speeds around the previously
-; stored base RPM.
-var lowerLimit = global.mosVSPS - global.mosVSV
-var upperLimit = global.mosVSPS + global.mosVSV
-
-if { var.upperLimit > spindles[global.mosSID].max }
-    set var.upperLimit = spindles[global.mosSID].max
-    set var.lowerLimit = { spindles[global.mosSID].max - (2*global.mosVSV) }
-    if { ! global.mosVSSW }
-        echo {"[VSSC]: Cannot increase spindle speed above " ^ spindles[global.mosSID].max ^ "! VSSC running between " ^ var.lowerLimit ^ " and " ^ var.upperLimit ^"RPM instead!" }
-        set global.mosVSSW=true
-
-; Fetch the previously stored base RPM
-var baseRPM = global.mosVSPS
-
-; If current RPM is outside of our calculated adjustment limits, then
-; store the RPM as our 'new' base, starting adjustment at the next cycle
-if { var.upperLimit < spindles[global.mosSID].active || spindles[global.mosSID].active < var.lowerLimit }
+; If current RPM is outside of our adjustment limits, then store the new
+; base RPM.
+if { spindles[global.mosSID].active < var.lowerLimit || spindles[global.mosSID].active > (var.lowerLimit + global.mosVSV ) }
     if { global.mosDebug }
         echo {"[VSSC] New base spindle RPM detected: " ^ spindles[global.mosSID].active }
-    set global.mosVSSW = false
     ; Set the RPM that we're going to adjust over in the next cycle
     set global.mosVSPS = spindles[global.mosSID].active
 
+    ; Reset elapsedTime
+    set global.mosVSPT = var.curTime
 else
-    ; Use the previous adjustment RPM for calculations
-    ; Assume previous adjustment direction was negative
-    var adjustedSpindleRPM = var.upperLimit
 
-    ; But override if it was positive
-    if { global.mosVSPD }
-        ; Previous adjustment was positive, so adjust negative
-        set var.adjustedSpindleRPM = var.lowerLimit
-
-    ; Update the adjustment direction by negating the boolean
-    set global.mosVSPD = !global.mosVSPD
+    ; Create a sinusoidal adjustment to the spindle speed based on the elapsed
+    ; time since the last adjustment.
+    var adjustedSpindleRPM = { ceil(var.lowerLimit + global.mosVSV * ((sin(2 * pi * var.elapsedTime / global.mosVSP) + 1) / 2)) }
 
     ; Set adjusted spindle RPM
     if { global.mosDebug }
         echo {"[VSSC] Adjusted spindle RPM: " ^ var.adjustedSpindleRPM }
     M568 F{ var.adjustedSpindleRPM }
-
-; Update adjustment time
-set global.mosVSPT = var.curTime

--- a/macro/public/3. Config/Settings/Toggle VSSC.g
+++ b/macro/public/3. Config/Settings/Toggle VSSC.g
@@ -3,10 +3,22 @@
 ; Toggles global.mosVSOE so that VSSC behaviour can be overridden
 ; by the operator on the fly.
 if { global.mosTM }
-    M291 R"MillenniumOS: Toggle VSSC" P{ (global.mosVSOE  ? "Disable" : "Enable" ) ^ " Variable Spindle Speed Control?" } S3
+    M291 R"MillenniumOS: Toggle VSSC Override" P{ (global.mosVSOE  ? "Disable" : "Enable" ) ^ " Variable Spindle Speed Control?" } S3
     if { result == -1 }
         M99
 
 set global.mosVSOE = {!global.mosVSOE}
 
-echo {"MillenniumOS: VSSC " ^ (global.mosVSOE ? "Enabled" : "Disabled")}
+; If VSSC override is disabled but VSSC
+; was enabled, reset the spindle speed
+; to the last recorded speed.
+if { !global.mosVSOE && global.mosVSEnabled }
+    if { spindles[global.mosSID].state == "forward" }
+        ; Set spindle RPM
+        M568 F{ global.mosVSPS }
+
+; Update adjustment time and RPM
+set global.mosVSPT = 0
+set global.mosVSPS = 0
+
+echo {"MillenniumOS: VSSC Override " ^ (global.mosVSOE ? "Enabled" : "Disabled")}

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -168,19 +168,19 @@ properties = {
   },
   vsscVariance: {
     title: "Variable Spindle Speed Control Variance",
-    description: "Variance above and below target RPM to vary Spindle speed when VSSC is enabled, in RPM.",
+    description: "Total variance in rpm to adjust around the requested spindle speed when VSSC is enabled. A value of 100 will vary the spindle speed from 50rpm below to 50rpm above the requested value.",
     group: "spindle",
     scope: ["post","operation"],
     type: "integer",
-    value: 100
+    value: 200
   },
   vsscPeriod: {
     title: "Variable Spindle Speed Control Period",
-    description: "Period over which RPM is varied up and down when VSSC is enabled, in milliseconds.",
+    description: "Period in milliseconds over which rpm is varied around the requested spindle speed when VSSC is enabled.",
     group: "spindle",
     scope: ["post","operation"],
     type: "integer",
-    value: 2000
+    value: 4000
   }
 };
 

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -138,10 +138,8 @@ global mosVSEnabled = false
 global mosVSOE = true
 global mosVSP = 0
 global mosVSV = 0.0
-global mosVSSW = false
 global mosVSPT = 0
 global mosVSPS = 0.0
-global mosVSPD = false
 
 ; Spindle configuration
 global mosSID = null


### PR DESCRIPTION
The original implementation of VSSC was a bit naive. Using a sine function to generate a number between 0 and 1, and then adjusting the speed from the lower limit forms a smooth adjustment that can be applied at every run of `daemon.g` instead of running a single RPM change to the top and the bottom of the limit.

However, this does change the implementation slightly. 

The VSSC period is now the time duration of a single wavelength, and the VSSC variance is now twice the amplitude of the wave - so calling `M7000 P2000 V500` would vary the spindle speed from `baseRPM - 250` (the lower limit) to `baseRPM + 250` (the upper limit) _and back_ in 2000ms.

This is unlikely to have significant implications for existing usage, but if a reduction in surface quality or increase in chatter is noticed, you should tweak your VSSC settings.

The Fusion360 post-processor has been updated to double the VSSC period and variance so the behaviour is now broadly similar to with the previous VSSC implementation.