### PR TITLE
Fix error on resume with no tool selected

### DIFF
--- a/sys/resume.g
+++ b/sys/resume.g
@@ -8,11 +8,11 @@ T R1
 
 ; If a tool was selected before the pause, try to
 ; restore the spindle speed.
-var toolRpm = tools[state.currentTool].spindleRpm
-if { state.currentTool >= 0 && var.toolRpm > 0 }
-    ; Restore spindle speed from before the pause
-    ; TODO: What about spindle direction?
-    M3.9 S{var.toolRpm}
+if { state.currentTool >= 0 && state.currentTool < limits.tools}
+    if { tools[state.currentTool].spindleRpm > 0 }
+        ; Restore spindle speed from before the pause
+        ; TODO: What about spindle direction?
+        M3.9 S{ tools[state.currentTool].spindleRpm }
 
 ; Move to X/Y position above the stored co-ordinates
 ; This will occur at machine Z=0 as we parked the


### PR DESCRIPTION
When resuming with no tool selected, an index out of bounds exception would be thrown because we were not properly checking whether the current tool was valid or not.

We now validate the current tool before trying to start the spindle after a pause.