### PR TITLE
Add Quick mode to `G6508` and `G6520`

### DIFF
--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -26,9 +26,9 @@ M598
 ; Display description of rectangle block probe if not already displayed this session
 if { global.mosTM && !global.mosDD10 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the corner of a rectangular workpiece by probing along the 2 edges that form the corner." R"MillenniumOS: Probe Outside Corner " T0 S2
-    M291 P"In full mode, this cycle will take 2 probe points on each edge, allowing us to calculate the position and angle of the corner and the rotation of the workpiece." R"MillenniumOS: Probe Outside Corner" T0 S2
+    M291 P"In <b>Full</b> mode, this cycle will take 2 probe points on each edge, allowing us to calculate the position and angle of the corner and the rotation of the workpiece." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"You will be asked to enter an approximate <b>surface length</b> for the surfaces forming the corner, to calculate the 4 probe locations." R"MillenniumOS: Probe Outside Corner" T0 S2
-    M291 P"In quick mode, this cycle will take 1 probe point on each edge, assuming the corner is square and the workpiece is aligned with the table, and will return the extrapolated position of the corner." R"MillenniumOS: Probe Outside Corner" T0 S2
+    M291 P"In <b>Quick</b> mode, this cycle will take 1 probe point on each edge, assuming the corner is square and the workpiece is aligned with the table, and will return the extrapolated position of the corner." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring when not triggered." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Outside Corner" T0 S2
@@ -43,11 +43,14 @@ if { global.mosPTID != state.currentTool }
 
 var tR = { global.mosTT[state.currentTool][0]}
 
-M291 P{"Please select the probing mode to use.<br/><b>Full</b> will probe 2 points on each edge, while <b>Quick</b> will probe only 1 point."} R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Full","Quick"}
+M291 P{"Please select the probing mode to use.<br/><b>Full</b> will probe 2 points on each horizontal surface, while <b>Quick</b> will probe only 1 point."} R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Full","Quick"} F0
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
 
 var mode = { input }
+
+var xSL  = null
+var ySL  = null
 
 ; 0 = Full mode, 1 = Quick mode
 if { var.mode == 0 }
@@ -56,9 +59,9 @@ if { var.mode == 0 }
     if { result != 0 }
         abort { "Outside corner probe aborted!" }
 
-    var xSurfaceLength = { input }
+    set var.xSL = { input }
 
-    if { var.xSurfaceLength < var.tR }
+    if { var.xSL < var.tR }
         abort { "X surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
     var sL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
@@ -66,9 +69,9 @@ if { var.mode == 0 }
     if { result != 0 }
         abort { "Outside corner probe aborted!" }
 
-    var ySurfaceLength = { input }
+    set var.ySL = { input }
 
-    if { var.ySurfaceLength < var.tR }
+    if { var.ySL < var.tR }
         abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for clearance distance
@@ -115,4 +118,4 @@ if { global.mosTM }
     if { result != 0 }
         abort { "Outside corner probe aborted!" }
 
-G6508.1 W{exists(param.W)? param.W : null} P{var.mode} H{var.xSurfaceLength} I{var.ySurfaceLength} N{var.corner} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6508.1 W{exists(param.W)? param.W : null} Q{var.mode} H{var.xSL} I{var.ySL} N{var.corner} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -31,6 +31,9 @@ if { !exists(param.H) || !exists(param.I) }
 if { !exists(param.P) }
     abort { "Must provide a probe depth below the top surface using the P parameter!" }
 
+if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) }
+    abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
+
 if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCnr) }
     abort { "Must provide a valid corner index using the N parameter!" }
 
@@ -66,7 +69,7 @@ if { global.mosWPSfcPos == null || global.mosWPSfcAxis != "Z" }
     abort { "G6520: Failed to probe the top surface of the workpiece!" }
 
 ; Probe the corner surface
-G6508.1 R0 W{exists(param.W)? param.W : null} H{param.H} I{param.I} N{param.N} T{param.T} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{ global.mosWPSfcPos - param.P}
+G6508.1 R0 W{exists(param.W)? param.W : null} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{ global.mosWPSfcPos - param.P}
 if { global.mosWPCnrNum == null }
     abort { "G6520: Failed to probe the corner surface of the workpiece!" }
 

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -26,8 +26,11 @@ M598
 
 ; Display description of vise corner probe if not already displayed this session
 if { global.mosTM && !global.mosDD11 }
-    M291 P"This probe cycle finds the X, Y and Z co-ordinates of the corner of a workpiece by probing the top surface and twice each along the 2 edges that form the corner." R"MillenniumOS: Probe Vise Corner" T0 S2
-    M291 P"You will be asked to enter approximate <b>surface lengths</b> for the surfaces forming the corner, a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"This probe cycle finds the X, Y and Z co-ordinates of the corner of a workpiece by probing the top surface and each of the edges that form the corner." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"In <b>Full</b> mode, this cycle will take 2 probe points on each edge, allowing us to calculate the position and angle of the corner and the rotation of the workpiece." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"You will be asked to enter an approximate <b>surface length</b> for the surfaces forming the corner, to calculate the 4 probe locations." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"In <b>Quick</b> mode, this cycle will take 1 probe point on each edge, assuming the corner is square and the workpiece is aligned with the table, and will return the extrapolated position of the corner." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Vise Corner" T0 S3
     if { result != 0 }
@@ -40,25 +43,37 @@ if { global.mosPTID != state.currentTool }
 
 var tR = { global.mosTT[state.currentTool][0]}
 
-var sW = { (global.mosWPDims[0] != null) ? global.mosWPDims[0] : 100 }
-M291 P{"Please enter approximate <b>surface length</b> along the X axis in mm.<br/><b>NOTE</b>: Along the X axis means the surface facing towards or directly away from the operator."} R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.sW}
+M291 P{"Please select the probing mode to use.<br/><b>Full</b> will probe 2 points on each horizontal surface, while <b>Quick</b> will probe only 1 point."} R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Full","Quick"} F0
 if { result != 0 }
-    abort { "Vise corner probe aborted!" }
+    abort { "Outside corner probe aborted!" }
 
-var xSurfaceLength = { input }
+var mode = { input }
 
-if { var.xSurfaceLength < var.tR }
-    abort { "X surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+var xSL  = null
+var ySL  = null
 
-var sL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
-M291 P{"Please enter approximate <b>surface length</b> along the Y axis in mm.<br/><b>NOTE</b>: Along the Y axis means the surface to the left or the right of the operator."} R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.sL}
-if { result != 0 }
-    abort { "Vise corner probe aborted!" }
+; 0 = Full mode, 1 = Quick mode
+if { var.mode == 0 }
 
-var ySurfaceLength = { input }
+    var sW = { (global.mosWPDims[0] != null) ? global.mosWPDims[0] : 100 }
+    M291 P{"Please enter approximate <b>surface length</b> along the X axis in mm.<br/><b>NOTE</b>: Along the X axis means the surface facing towards or directly away from the operator."} R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.sW}
+    if { result != 0 }
+        abort { "Vise corner probe aborted!" }
 
-if { var.ySurfaceLength < var.tR }
-    abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+    set var.xSL = { input }
+
+    if { var.xSL < var.tR }
+        abort { "X surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+
+    var sL = { (global.mosWPDims[1] != null) ? global.mosWPDims[1] : 100 }
+    M291 P{"Please enter approximate <b>surface length</b> along the Y axis in mm.<br/><b>NOTE</b>: Along the Y axis means the surface to the left or the right of the operator."} R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.sL}
+    if { result != 0 }
+        abort { "Vise corner probe aborted!" }
+
+    set var.ySL = { input }
+
+    if { var.ySL < var.tR }
+        abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for clearance distance
 M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far far out we move from the expected surface to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosCL}
@@ -104,4 +119,4 @@ if { global.mosTM }
     if { result != 0 }
         abort { "Vise corner probe aborted!" }
 
-G6520.1 W{exists(param.W)? param.W : null} H{var.xSurfaceLength} I{var.ySurfaceLength} N{var.corner} T{var.clearance} O{var.overtravel} P{var.probeDepth} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}
+G6520.1 W{exists(param.W)? param.W : null} Q{var.mode} H{var.xSL} I{var.ySL} N{var.corner} T{var.clearance} O{var.overtravel} P{var.probeDepth} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -42,7 +42,7 @@ if { state.nextTool == global.mosPTID }
     ; If touch probe is enabled, prompt the operator to install
     ; it and check for activation.
     if { global.mosFeatTouchProbe }
-        M291 P{"Please install your touch probe into the spindle and make sure it is connected.<br/>When ready, press <b>OK</b>, and then manually activate it until it is detected."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
+        M291 P{"Please install your touch probe into the spindle and make sure it is connected.<br/>When ready, press <b>Continue</b>, and then manually activate it until it is detected."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
         if { input != 0 }
             abort { "Tool change aborted by operator!" }
 
@@ -56,7 +56,7 @@ if { state.nextTool == global.mosPTID }
             abort {"Did not detect a touch probe with ID " ^ global.mosTPID ^ "! Please check your probe connection and run T" ^ global.mosPTID ^ " again to verify it is connected."}
     else
         ; If no touch probe enabled, ask user to install datum tool.
-        M291 P{"Please install your datum tool into the spindle. When ready, press <b>OK</b>."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
+        M291 P{"Please install your datum tool into the spindle. When ready, press <b>Continue</b>."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
         if { input != 0 }
             abort { "Tool change aborted by operator, aborting job!" }
         echo { "Touch probe feature disabled, manual probing will use an installed datum tool." }


### PR DESCRIPTION
On a machine with a well-trammed table, vice and a known-square stock, it isn't always necessary to calculate the rotation of a workpiece - you just want the X, Y and Z co-ordinates for the work origin.

This PR adds a Quick mode (`Q=1`) to both `G6508` (Outside Corner) and `G6520` (Vise Corner) probing cycles, skipping the second probe point along the X and Y surfaces.

This makes manual probing considerably faster and saves probing time when using a touch probe as well, but means we can no longer compensate for workpiece rotation. Which isn't even implemented yet.