### PR TITLE
Add Z reset procedure for toolsetter-less tool changes

### DIFF
--- a/macro/movement/G37.1.g
+++ b/macro/movement/G37.1.g
@@ -1,0 +1,74 @@
+; G37.1.g: PROBE Z SURFACE WITH CURRENT TOOL
+;
+; When the toolsetter is disabled, we have no way of
+; calculating relative tool lengths - so we can't know the
+; length of the touch probe (if enabled) or probe the length
+; of any tools.
+
+; When a tool change occurs, we must re-zero the Z origin of
+; the current WCS by using a manual probe with the currently
+; installed tool.
+
+; This macro effectively does a single Z surface probe like
+; G6510, but without forcing a switch to the probe tool (manual
+; or touch probe) first.
+
+; NOTE: YOU SHOULD NEVER USE THIS OUTSIDE OF TOOL CHANGES, AS
+; THIS IS COMPLETELY UNTESTED OUTSIDE OF THIS PARTICULAR USAGE
+; AND IS NOT DESIGNED AS A GENERALISED PROBING MACRO.
+
+; Make sure this file is not executed by the secondary motion system
+if { !inputs[state.thisInput].active }
+    M99
+
+; Make sure we're in the default motion system
+M598
+
+var wPN = { move.workplaceNumber + 1 }
+
+if { global.mosTM && !global.mosDD12 }
+    M291 P{"The <b>Toolsetter</b> feature is disabled, so you must set the Z origin in the current WCS after each tool change.<br/>We will run a manual probe cycle to do this."} R"MillenniumOS: Reset Z Origin" S2 T0
+    M291 P{"You <b>MUST</b> probe the location where WCS " ^ var.wPN ^ " expects the Z origin to be.<br/>Check in your CAM program to confirm where this is!"} R"MillenniumOS: Reset Z Origin" S2 T0
+    set global.mosDD12 = true
+
+; Ask the operator to jog to their chosen starting position
+M291 P"Please jog the tool above your origin point in Z.<br/><b>CAUTION</b>: Remember - Jogging in RRF does <b>NOT</b> watch the probe status. Be careful!" R"MillenniumOS: Reset Z Origin" X1 Y1 Z1 T0 S3
+if { result != 0 }
+    abort { "G37.1: Surface probe aborted!" }
+
+
+M291 P"Please enter the distance to probe towards the surface in mm." R"MillenniumOS: Reset Z Origin" J1 T0 S6 F{global.mosCL}
+if { result != 0 }
+    abort { "G37.1: Surface probe aborted!" }
+
+var probeDist = { input }
+
+if { var.probeDist < 0 }
+    abort { "G37.1: Probe distance was negative!" }
+
+; Prompt for overtravel distance
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Reset Z Origin" J1 T0 S6 F{global.mosOT}
+if { result != 0 }
+    echo "Probe Abort"
+    abort { "G37.1: Surface probe aborted!" }
+
+var overtravel = { input }
+if { var.overtravel < 0 }
+    abort { "G37.1: Overtravel distance must not be negative!" }
+
+var tPZ = { move.axes[2].machinePosition - var.probeDist - var.overtravel }
+
+; Check if the position is within machine limits
+M6515 Z{ var.tPZ }
+
+; Run a manual probe to target Z location
+G6512 L{move.axes[2].machinePosition} Z{var.tPZ}
+
+if { global.mosPCZ == null }
+    abort { "G37.1: Surface probe failed!" }
+
+; Park in Z
+G27 Z1
+
+echo { "MillenniumOS: Setting WCS " ^ var.wPN ^ " Z origin to probed co-ordinate." }
+G10 L2 P{var.wPN} Z{global.mosPCZ}

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -140,5 +140,5 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed corner, if requested
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of bore" }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of bore." }
     G10 L2 P{param.W} X{var.cX} Y{var.cY}

--- a/macro/movement/G6500.g
+++ b/macro/movement/G6500.g
@@ -20,8 +20,8 @@ if { global.mosTM && !global.mosDD2 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular bore (hole) in a workpiece by moving downwards into the bore and probing outwards in 3 directions." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will be asked to enter an approximate <b>bore diameter</b> and <b>overtravel distance</b>.<br/>These define how far the probe will move from the centerpoint, without being triggered, before erroring." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will then jog the tool over the approximate center of the bore.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Bore" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the bore before probing outwards. Press ""OK"" to continue." R"MillenniumOS: Probe Bore" T0 S3
-    if { result != 0 }
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the bore before probing outwards." R"MillenniumOS: Probe Bore" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Bore probe aborted!" }
     set global.mosDD2 = true
 
@@ -70,8 +70,8 @@ if { var.probingDepth < 0 }
 
 ; Run the bore probe cycle
 if { global.mosTM }
-    M291 P{"Probe will now move downwards " ^ var.probingDepth ^ "mm into the bore and probe towards the edge in 3 directions."} R"MillenniumOS: Probe Bore" J1 T0 S3
-    if { result != 0 }
+    M291 P{"Probe will now move downwards " ^ var.probingDepth ^ "mm into the bore then probe towards the edge in 3 directions."} R"MillenniumOS: Probe Bore" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Bore probe aborted!" }
 
 G6500.1 W{exists(param.W)? param.W : null} H{var.boreDiameter} O{var.overTravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -166,5 +166,5 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed boss center, if requested
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of boss" }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of boss." }
     G10 L2 P{param.W} X{var.cX} Y{var.cY}

--- a/macro/movement/G6501.g
+++ b/macro/movement/G6501.g
@@ -20,8 +20,8 @@ if { global.mosTM && !global.mosDD3 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular boss (protruding feature) on a workpiece by probing towards the approximate center of the boss in 3 directions." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will be asked to enter an approximate <b>boss diameter</b> and <b>clearance distance</b>.<br/>These define how far the probe will move away from the centerpoint before probing back inwards." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will then jog the tool over the approximate center of the boss.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Boss" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards after moving outside of the boss diameter, and before probing towards the centerpoint. Press ""OK"" to continue." R"MillenniumOS: Probe Boss" T0 S3
-    if { result != 0 }
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing back towards the centerpoint." R"MillenniumOS: Probe Boss" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Boss probe aborted!" }
     set global.mosDD3 = true
 
@@ -72,8 +72,8 @@ if { var.probingDepth <= 0}
 
 ; Run the boss probe cycle
 if { global.mosTM }
-    M291 P{"Probe will now move outwards by " ^ {(var.bossDiameter/2) + var.clearance} ^ "mm and then downwards " ^ var.probingDepth ^ "mm, before probing towards the edge in 3 directions."} R"MillenniumOS: Probe Boss" T0 S3
-    if { result != 0 }
+    M291 P{"Probe will now move outwards by " ^ {(var.bossDiameter/2) + var.clearance} ^ "mm, then downwards " ^ var.probingDepth ^ "mm, before probing back towards the center at 3 points."} R"MillenniumOS: Probe Boss" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Boss probe aborted!" }
 
 G6501.1 W{exists(param.W)? param.W : null} H{var.bossDiameter} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6502.1.g
+++ b/macro/movement/G6502.1.g
@@ -338,5 +338,5 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed center, if requested
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of rectangle pocket" }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of rectangle pocket." }
     G10 L2 P{param.W} X{global.mosWPCtrPos[0]} Y{global.mosWPCtrPos[1]}

--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -22,8 +22,8 @@ if { global.mosTM && !global.mosDD6 }
     M291 P"You will be asked to enter an approximate <b>width</b> and <b>height</b> of the pocket, and a <b>clearance distance</b>." R"MillenniumOS: Probe Rect. Pocket" T0 S2
     M291 P"These define how far the probe will move away from the center point before starting to probe towards the relevant surfaces." R"MillenniumOS: Probe Rect. Pocket" T0 S2
     M291 P"You will then jog the tool over the approximate center of the pocket.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Rect. Pocket" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the pocket before probing towards the edges. Press ""OK"" to continue." R"MillenniumOS: Probe Rect. Pocket" T0 S3
-    if { result != 0 }
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the pocket before probing towards the edges." R"MillenniumOS: Probe Rect. Pocket" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Rectangle pocket probe aborted!" }
     set global.mosDD6 = true
 
@@ -54,7 +54,7 @@ if { var.pocketLength < 1 }
     abort { "Pocket length too low!" }
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surfaces we start probing from, to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Rectangle pocket probe aborted!" }
 
@@ -63,7 +63,7 @@ if { var.clearance < 1 }
     abort { "Clearance distance too low!" }
 
 ; Prompt for overtravel distance
-M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
     abort { "Rectangle pocket probe aborted!" }
 
@@ -86,8 +86,8 @@ if { var.probingDepth < 0 }
 
 ; Run the pocket probe cycle
 if { global.mosTM }
-    M291 P{"Probe will now move down by " ^ var.probingDepth ^ "mm, before probing towards each of the pocket surfaces at 2 locations."} R"MillenniumOS: Probe Rect. Pocket" T0 S3
-    if { result != 0 }
+    M291 P{"Probe will now move down by " ^ var.probingDepth ^ "mm, before probing towards each of the pocket surfaces at 2 locations."} R"MillenniumOS: Probe Rect. Pocket" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Rectangle pocket probe aborted!" }
 
 G6502.1 W{exists(param.W)? param.W : null} H{var.pocketWidth} I{var.pocketLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -334,5 +334,5 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed center, if requested
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of rectangle block" }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to center of rectangle block." }
     G10 L2 P{param.W} X{global.mosWPCtrPos[0]} Y{global.mosWPCtrPos[1]}

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -22,8 +22,8 @@ if { global.mosTM && !global.mosDD5 }
     M291 P"You will be asked to enter an approximate <b>width</b> and <b>height</b> of the block, and a <b>clearance distance</b>." R"MillenniumOS: Probe Rect. Block" T0 S2
     M291 P"These define how far the probe will move away from the center point before moving downwards and probing back towards the relevant surfaces." R"MillenniumOS: Probe Rect. Block" T0 S2
     M291 P"You will then jog the tool over the approximate center of the block.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Rect. Block" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing towards the centerpoint. Press ""OK"" to continue." R"MillenniumOS: Probe Rect. Block" T0 S3
-    if { result != 0 }
+    M291 P"Finally, you will be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing towards the centerpoint." R"MillenniumOS: Probe Rect. Block" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Rectangle block probe aborted!" }
     set global.mosDD5 = true
 
@@ -54,7 +54,7 @@ if { var.blockLength < 1 }
     abort { "Block length too low!" }
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far out we move from the expected surfaces to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surfaces we start probing from, to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Rectangle block probe aborted!" }
 
@@ -64,7 +64,7 @@ if { var.clearance < 1 }
     abort { "Clearance distance too low!" }
 
 ; Prompt for overtravel distance
-M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far in we move from the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
     abort { "Rectangle block probe aborted!" }
 
@@ -87,8 +87,8 @@ if { var.probingDepth < 0 }
 
 ; Run the block probe cycle
 if { global.mosTM }
-    M291 P{"Probe will now move outside each surface and down by " ^ var.probingDepth ^ "mm, before probing towards the center."} R"MillenniumOS: Probe Rect. Block" T0 S3
-    if { result != 0 }
+    M291 P{"Probe will now move outside each surface and down by " ^ var.probingDepth ^ "mm, before probing towards the center."} R"MillenniumOS: Probe Rect. Block" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Rectangle block probe aborted!" }
 
 G6503.1 W{exists(param.W)? param.W : null} H{var.blockWidth} I{var.blockLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -272,5 +272,5 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed center, if requested
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to corner " ^ global.mosCnr[param.N] }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " X,Y origin to corner " ^ global.mosCnr[param.N] ^ "." }
     G10 L2 P{param.W} X{global.mosWPCnrPos[0]} Y{global.mosWPCnrPos[1]}

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -30,10 +30,10 @@ if { global.mosTM && !global.mosDD10 }
     M291 P"You will be asked to enter an approximate <b>surface length</b> for the surfaces forming the corner, to calculate the 4 probe locations." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"In <b>Quick</b> mode, this cycle will take 1 probe point on each edge, assuming the corner is square and the workpiece is aligned with the table, and will return the extrapolated position of the corner." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Outside Corner" T0 S2
-    M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring when not triggered." R"MillenniumOS: Probe Outside Corner" T0 S2
+    M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far past the expected surface the probe can move before erroring when not triggered." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Outside Corner" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing towards the corner surfaces. Press <b>OK</b> to continue." R"MillenniumOS: Probe Outside Corner" T0 S3
-    if { result != 0 }
+    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Outside Corner" S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Outside corner probe aborted!" }
     set global.mosDD10 = true
 
@@ -75,7 +75,7 @@ if { var.mode == 0 }
         abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far far out we move from the expected surface to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surface we start probing from, to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
 
@@ -84,7 +84,7 @@ if { var.clearance < var.tR }
     abort { Clearance distance too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for overtravel distance
-M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far far in we move from the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
 
@@ -114,8 +114,8 @@ if { var.probingDepth < 0 }
 ; Run the block probe cycle
 if { global.mosTM }
     var cN = { global.mosCnr[var.corner] }
-    M291 P{"Probe will now move outside the <b>" ^ var.cN ^ "</b> corner and down by " ^ var.probingDepth ^ "mm, before probing 2 points " ^ var.clearance ^ "mm from each end of the surfaces." } R"MillenniumOS: Probe Outside Corner" T0 S3
-    if { result != 0 }
+    M291 P{"We will now move outside the <b>" ^ var.cN ^ "</b> corner, down by " ^ var.probingDepth ^ "mm and probe each surface forming the corner." } R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Outside corner probe aborted!" }
 
 G6508.1 W{exists(param.W)? param.W : null} Q{var.mode} H{var.xSL} I{var.ySL} N{var.corner} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -85,7 +85,7 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS if required
 if { exists(param.W) && param.W != null }
-    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " " ^ var.sAxis ^ " origin to probed co-ordinate" }
+    echo { "MillenniumOS: Setting WCS " ^ param.W ^ " " ^ var.sAxis ^ " origin to probed co-ordinate." }
     if { var.probeAxis <= 1 }
         G10 L2 P{param.W} X{global.mosWPSfcPos}
     elif { var.probeAxis <= 3 }

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -34,8 +34,8 @@ if { global.mosTM && !global.mosDD4 }
     M291 P"<b>CAUTION</b>: Jogging in RRF does <b>NOT</b> watch the probe status. Be careful!" R"MillenniumOS: Probe Surface" T0 S2
     M291 P"<b>CAUTION</b>: For X or Y surfaces, the probe will move down <b>BEFORE</b> moving horizontally to detect a surface. Bear this in mind when selecting a starting position." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"For X or Y surfaces, you will then be asked for a <b>probe depth</b>. This is how far your probe will move down from the starting position before moving in X or Y." R"MillenniumOS: Probe Surface" T0 S2
-    M291 P"Finally, you will be asked to set a <b>probe distance</b>. This is how far the probe will move towards a surface before returning an error if it did not trigger." R"MillenniumOS: Probe Surface" T0 S3
-    if { result != 0 }
+    M291 P"Finally, you will be asked to set a <b>probe distance</b>. This is how far the probe will move towards a surface before returning an error if it did not trigger." R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Surface probe aborted!" }
 
     set global.mosDD4 = true
@@ -45,7 +45,7 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Prompt for overtravel distance
-M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far far in we move from the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Surface" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
     abort { "Single Surface probe aborted!" }
 
@@ -78,7 +78,7 @@ if { !var.isZProbe }
     if { var.probeDepth < 0 }
         abort { "Probing depth was negative!" }
 
-M291 P"Please enter the distance to probe towards the surface in mm." R"MillenniumOS: Probe Surface" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter the distance to probe towards the surface in mm." R"MillenniumOS: Probe Surface" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Surface probe aborted!" }
 
@@ -89,12 +89,12 @@ if { var.probeDist < 0 }
 
 if { global.mosTM }
     if { !var.isZProbe }
-        M291 P{"Probe will now move down <b>" ^ var.probeDepth ^ "</b> mm and probe towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S3
-        if { result != 0 }
+        M291 P{"Probe will now move down <b>" ^ var.probeDepth ^ "</b> mm and probe towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+        if { input != 0 }
             abort { "Single Surface probe aborted!" }
     else
-        M291 P{"Probe will now move towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S3
-        if { result != 0 }
+        M291 P{"Probe will now move towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+        if { input != 0 }
             abort { "Single Surface probe aborted!" }
 
 

--- a/macro/movement/G6511.g
+++ b/macro/movement/G6511.g
@@ -28,8 +28,6 @@ G94
 ; probe the reference surface but we must not abort - this command should be
 ; a no-op.
 if { !global.mosFeatTouchProbe || !global.mosFeatToolSetter }
-    ; Commented due to memory limitations
-    ; M7500 S{"Reference surface probe is not required, touch probe or toolsetter feature is not enabled."}
     M99
 
 if { global.mosTSAP != null && (!exists(param.R) || param.R == 0) }

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -100,7 +100,7 @@ if { !exists(param.L) }
     abort { "G6512: Must provide Z height to begin probing at (L..)!" }
 
 if { state.currentTool >= #tools || state.currentTool < 0 }
-    abort { "G6512: No tool selected, or MillenniumOS tool table is invalid. Select a probe tool before probing."}
+    abort { "G6512: No tool selected! Select a tool before probing."}
 
 var sZ = { param.L }
 
@@ -128,14 +128,14 @@ G94
 ; If starting probe height is above safe height (current Z),
 ; then move to the starting probe height first.
 if { var.sZ > var.safeZ }
-    G6550 I{ param.I } Z{ var.sZ }
+    G6550 I{ exists(param.I) ? param.I : null } Z{ var.sZ }
 
 ; Move to starting position in X and Y
-G6550 I{ param.I } X{ var.sX } Y{ var.sY }
+G6550 I{ exists(param.I) ? param.I : null } X{ var.sX } Y{ var.sY }
 
 ; Move to probe height.
 ; No-op if we already moved above.
-G6550 I{ param.I } Z{ var.sZ }
+G6550 I{ exists(param.I) ? param.I : null } Z{ var.sZ }
 
 ; Run automated probing cycle
 if { var.manualProbe }
@@ -147,7 +147,7 @@ else
 ; If probing move is called with D parameter,
 ; we stay at the same height.
 if { !exists(param.D) }
-    G6550 I{ param.I } Z{ var.safeZ }
+    G6550 I{ exists(param.I) ? param.I : null } Z{ var.safeZ }
 
 M400
 

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -31,9 +31,10 @@ if { global.mosTM && !global.mosDD11 }
     M291 P"You will be asked to enter an approximate <b>surface length</b> for the surfaces forming the corner, to calculate the 4 probe locations." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"In <b>Quick</b> mode, this cycle will take 1 probe point on each edge, assuming the corner is square and the workpiece is aligned with the table, and will return the extrapolated position of the corner." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Vise Corner" T0 S2
-    M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far inwards from the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Vise Corner" T0 S2
-    M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Vise Corner" T0 S3
-    if { result != 0 }
+    M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far past the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status - <b>Be Careful!</b>" R"MillenniumOS: Probe Vise Corner" T0 S2
+    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Vise Corner" S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Vise corner probe aborted!" }
     set global.mosDD11 = true
 
@@ -76,7 +77,7 @@ if { var.mode == 0 }
         abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far far out we move from the expected surface to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surface we start probing from, to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
@@ -85,7 +86,7 @@ if { var.clearance < var.tR }
     abort { Clearance distance too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for overtravel distance
-M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far far in we move from the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosOT}
+M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
@@ -115,8 +116,8 @@ if { var.probeDepth < 0 }
 ; Run the block probe cycle
 if { global.mosTM }
     var cN = { global.mosCnr[var.corner] }
-    M291 P{"We will now probe the top surface, then move outside the <b>" ^ var.cN ^ "</b> corner and down " ^ var.probeDepth ^ "mm, then probe 2 points " ^ var.clearance ^ "mm from each end of the corner surfaces." } R"MillenniumOS: Probe Vise Corner" T0 S3
-    if { result != 0 }
+    M291 P{"We will now probe the top surface, then move outside the <b>" ^ var.cN ^ "</b> corner, down " ^ var.probeDepth ^ "mm, and probe each surface forming the corner." } R"MillenniumOS: Probe Vise Corner" T0 S4 K{"Continue", "Cancel"} F0
+    if { input != 0 }
         abort { "Vise corner probe aborted!" }
 
 G6520.1 W{exists(param.W)? param.W : null} Q{var.mode} H{var.xSL} I{var.ySL} N{var.corner} T{var.clearance} O{var.overtravel} P{var.probeDepth} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -39,9 +39,6 @@ if { !exists(param.X) && !exists(param.Y) && !exists(param.Z) }
 
 var manualProbe = { !exists(param.I) || param.I == null }
 
-if { var.manualProbe && global.mosFeatTouchProbe }
-    abort { "G6550: Attempt to use unprotected move with touch probe enabled. Did you pass the probe ID (I...)?" }
-
 ; Make sure machine is stationary before checking machine positions
 M400
 
@@ -68,8 +65,6 @@ G94
 ; So just run the move as normal with our manual
 ; probing travel speed and then return.
 if { var.manualProbe }
-    ; Commented due to memory limitations
-    ; M7500 S{"Unprotected move to X=" ^ var.tPX ^ " Y=" ^ var.tPY ^ " Z=" ^ var.tPZ ^ " as touch probe is not available."}
     G53 G1 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ } F{ global.mosMPS[0] }
     M99
 

--- a/macro/tool-change/tfree.g
+++ b/macro/tool-change/tfree.g
@@ -22,9 +22,9 @@ G27 Z1
 ; If probe tool is selected
 if { state.currentTool == global.mosPTID }
     if { global.mosFeatTouchProbe }
-        M291 P{"Please remove the touch probe now and stow it safely away from the machine. Click <b>OK</b> when stowed safely."} R{"MillenniumOS: Touch Probe"} S2
+        M291 P{"Please remove the <b>Touch Probe</b> now and stow it safely away from the machine. Click <b>OK</b> when stowed safely."} R{"MillenniumOS: Touch Probe"} S2
     else
-        M291 P{"Please remove the datum tool now and stow it safely away from the machine. Click <b>OK</b> when stowed safely."} R{"MillenniumOS: Datum Tool"} S2
+        M291 P{"Please remove the <b>Datum Tool</b> now and stow it safely away from the machine. Click <b>OK</b> when stowed safely."} R{"MillenniumOS: Datum Tool"} S2
 
 ; Set tool change state to tfree complete
 set global.mosTCS = 1

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -42,7 +42,7 @@ if { state.nextTool == global.mosPTID }
     ; If touch probe is enabled, prompt the operator to install
     ; it and check for activation.
     if { global.mosFeatTouchProbe }
-        M291 P{"Please install your touch probe into the spindle and make sure it is connected.<br/>When ready, press <b>Continue</b>, and then manually activate it until it is detected."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
+        M291 P{"Please install your <b>Touch Probe</b> into the spindle and make sure it is connected.<br/>When ready, press <b>Continue</b>, and then manually activate it until it is detected."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
         if { input != 0 }
             abort { "Tool change aborted by operator!" }
 
@@ -53,17 +53,17 @@ if { state.nextTool == global.mosPTID }
 
         ; Check if requested probe ID was detected.
         if { global.mosPD != global.mosTPID }
-            abort {"Did not detect a touch probe with ID " ^ global.mosTPID ^ "! Please check your probe connection and run T" ^ global.mosPTID ^ " again to verify it is connected."}
+            abort {"Did not detect a <b>Touch Probe</b> with ID " ^ global.mosTPID ^ "! Please check your Probe connection and run T" ^ global.mosPTID ^ " again to verify it is connected."}
     else
         ; If no touch probe enabled, ask user to install datum tool.
-        M291 P{"Please install your datum tool into the spindle. When ready, press <b>Continue</b>."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
+        M291 P{"Please install your <b>Datum Tool</b> into the spindle. When ready, press <b>Continue</b>."} R"MillenniumOS: Probe Tool" S4 K{"Continue", "Cancel"}
         if { input != 0 }
             abort { "Tool change aborted by operator, aborting job!" }
-        echo { "Touch probe feature disabled, manual probing will use an installed datum tool." }
+        echo { "Touch Probe feature disabled, manual probing will use an installed datum tool." }
 else
 
-    if { global.mosFeatTouchProbe && global.mosTSAP == null }
-        abort { "Touch probe feature is enabled but reference surface has not been probed. Please run G6511 first, then back to this tool using T" ^ state.nextTool ^ "."}
+    if { global.mosFeatTouchProbe && global.mosFeatToolSetter && global.mosTSAP == null }
+        abort { "Touch Probe and Toolsetter are enabled but reference surface has not been probed. Please run G6511 first, then switch back to this tool using T" ^ state.nextTool ^ "."}
 
     ; All other tools cannot be detected so we just have to
     ; trust the operator did the right thing given the

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -197,8 +197,8 @@ global mosPD = null
 ; Tracks whether description messages have been
 ; displayed during this session. The first 2 indexes
 ; are used by the G6600 macro, the others are used by
-; G6500 to G6509, one each, in order. G6520 uses the
-; last index.
+; G6500 to G6509, one each, in order. G6520 uses mosDD11,
+; and G37.1 uses the last index.
 global mosDD0 = false
 global mosDD1 = false
 global mosDD2 = false
@@ -211,3 +211,4 @@ global mosDD8 = false
 global mosDD9 = false
 global mosDD10 = false
 global mosDD11 = false
+global mosDD12 = false


### PR DESCRIPTION
We add `G37.1` which is a Z surface probing procedure that does not change to the probing tool before running a manual-only probing procedure.

We integrate this into the tool change macros so if the toolsetter is not enabled, the Z origin can be reset at each tool change. MillenniumOS can now be used without a touch probe or a toolsetter!

We also try to reduce the usage of the S3 dialog mode as clicking Cancel on this dialog does not pass the cancel back to the calling macro, and might continue processing where we would expect it to... not. We still have to use it when expecting the operator to jog, because jogging is only supported on S<=3 modes, but we are now 'safer' where we can be.

We now only probe the reference surface if both the toolsetter and touch probe feature are enabled.

We fix a number of tutorial mode prompts and make some copy changes to make these clearer.