### PR TITLE
Escape various characters in string post outputs

### DIFF
--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -23,6 +23,7 @@ import sys
 import pprint
 import argparse
 import shlex
+import re
 from enum import StrEnum, Flag, auto
 from contextlib import contextmanager
 import FreeCAD
@@ -142,6 +143,11 @@ parser.add_argument('--vssc', action=argparse.BooleanOptionalAction, default=Tru
     which helps to avoid harmonic resonance between tool and work piece.
     """)
 
+
+# RRF Strings are not allowed to contain certain characters and
+# quotes must be doubled up.
+def rrf_safe_string(s):
+    return re.sub(r'([^"0-9a-z\.:,=_\-\s])', "", s, flags=re.IGNORECASE).replace('"', '""')
 
 # Define output class. This is used to output both
 # commands and their nested variables. Output() instances
@@ -672,7 +678,7 @@ class MillenniumOSPostProcessor(PostProcessor):
                 # Output tool info
                 for index, tool in tools.items():
                     tool_desc = ' '.join([tool['name'], "F={flutes} L={flute_length} CR={corner_radius}".format(**tool['params'])])
-                    self.M(MCODES.ADD_TOOL, P=index, R=tool['params']['radius'], S=tool_desc, ctrl=Control.FORCE)
+                    self.M(MCODES.ADD_TOOL, P=index, R=tool['params']['radius'], S=rrf_safe_string(tool_desc), ctrl=Control.FORCE)
                 self.brk()
 
             if self.args.home_before_start:

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -25,7 +25,18 @@ String.prototype.supplant = function (o) {
     return this.replace(/{([^{}]*)}/g,
         function (a, b) {
             var r = o[b];
-            return typeof r === 'string' || typeof r === 'number' ? r : a;
+            switch(typeof r) {
+              case 'string':
+                // Allow only alphanumeric characters, colons, periods,
+                // commas, underscores, hyphens and spaces. Replace all
+                // double quotes with two double quotes so these are escaped
+                // by RRF when outputted.
+                return r.replace(/([^"0-9a-z\.:,=_\-\s])/gi, "").replace(/"/g, '""')
+              case 'number':
+                return r;
+              default:
+                return a;
+            }
         }
     );
 };


### PR DESCRIPTION
We strip most non-alphanumeric characters, and make sure each double quote is doubled ("2"" ..." => '2" ...') as this is how RRF expects them to be escaped.