### PR TITLE
Add probe cycle links

### DIFF
--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -69,9 +69,9 @@ var sZ   = { param.L }
 
 ; Calculate probing directions using approximate bore radius
 ; Angle is in degrees
-var angle = 120
+var angle = radians(120)
 
-var dirXY = { { var.sX + var.bR, var.sY}, { var.sX + var.bR * cos(radians(var.angle)), var.sY + var.bR * sin(radians(var.angle)) }, { var.sX + var.bR * cos(radians(2 * var.angle)), var.sY + var.bR * sin(radians(2 * var.angle)) } }
+var dirXY = { { var.sX + var.bR, var.sY}, { var.sX + var.bR * cos(var.angle), var.sY + var.bR * sin(var.angle) }, { var.sX + var.bR * cos(2 * var.angle), var.sY + var.bR * sin(2 * var.angle) } }
 
 ; Bore edge co-ordinates for 3 probed points
 var pXY  = { null, null, null }

--- a/macro/movement/G6500.g
+++ b/macro/movement/G6500.g
@@ -20,7 +20,8 @@ if { global.mosTM && !global.mosDD2 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular bore (hole) in a workpiece by moving downwards into the bore and probing outwards in 3 directions." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will be asked to enter an approximate <b>bore diameter</b> and <b>overtravel distance</b>.<br/>These define how far the probe will move from the centerpoint, without being triggered, before erroring." R"MillenniumOS: Probe Bore" T0 S2
     M291 P"You will then jog the tool over the approximate center of the bore.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Bore" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the bore before probing outwards." R"MillenniumOS: Probe Bore" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the bore before probing outwards." R"MillenniumOS: Probe Bore" T0 S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/circular-bore"">View the Circular Bore Documentation</a> for more details." R"MillenniumOS: Probe Bore" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Bore probe aborted!" }
     set global.mosDD2 = true

--- a/macro/movement/G6501.g
+++ b/macro/movement/G6501.g
@@ -20,7 +20,8 @@ if { global.mosTM && !global.mosDD3 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular boss (protruding feature) on a workpiece by probing towards the approximate center of the boss in 3 directions." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will be asked to enter an approximate <b>boss diameter</b> and <b>clearance distance</b>.<br/>These define how far the probe will move away from the centerpoint before probing back inwards." R"MillenniumOS: Probe Boss" T0 S2
     M291 P"You will then jog the tool over the approximate center of the boss.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Boss" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing back towards the centerpoint." R"MillenniumOS: Probe Boss" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing back towards the centerpoint." R"MillenniumOS: Probe Boss" T0 S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/circular-boss"">View the Circular Boss Documentation</a> for more details." R"MillenniumOS: Probe Boss" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Boss probe aborted!" }
     set global.mosDD3 = true

--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -22,7 +22,8 @@ if { global.mosTM && !global.mosDD6 }
     M291 P"You will be asked to enter an approximate <b>width</b> and <b>length</b> of the pocket, and a <b>clearance distance</b>." R"MillenniumOS: Probe Rect. Pocket" T0 S2
     M291 P"These define how far the probe will move away from the center point before starting to probe towards the relevant surfaces." R"MillenniumOS: Probe Rect. Pocket" T0 S2
     M291 P"You will then jog the tool over the approximate center of the pocket.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Rect. Pocket" T0 S2
-    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the pocket before probing towards the edges." R"MillenniumOS: Probe Rect. Pocket" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"You will then be asked for a <b>probe depth</b>. This is how far the probe will move downwards into the pocket before probing towards the edges." R"MillenniumOS: Probe Rect. Pocket" T0 S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/rectangle-pocket"">View the Rectangle Pocket Documentation</a> for more details." R"MillenniumOS: Probe Rect. Pocket" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Rectangle pocket probe aborted!" }
     set global.mosDD6 = true

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -22,7 +22,8 @@ if { global.mosTM && !global.mosDD5 }
     M291 P"You will be asked to enter an approximate <b>width</b> and <b>length</b> of the block, and a <b>clearance distance</b>." R"MillenniumOS: Probe Rect. Block" T0 S2
     M291 P"These define how far the probe will move away from the center point before moving downwards and probing back towards the relevant surfaces." R"MillenniumOS: Probe Rect. Block" T0 S2
     M291 P"You will then jog the tool over the approximate center of the block.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Rect. Block" T0 S2
-    M291 P"Finally, you will be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing towards the centerpoint." R"MillenniumOS: Probe Rect. Block" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"Finally, you will be asked for a <b>probe depth</b>. This is how far the probe will move downwards before probing towards the centerpoint." R"MillenniumOS: Probe Rect. Block" T0 S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/rectangle-block"">View the Rectangle Block Documentation</a> for more details." R"MillenniumOS: Probe Rect. Block" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Rectangle block probe aborted!" }
     set global.mosDD5 = true

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -32,7 +32,8 @@ if { global.mosTM && !global.mosDD10 }
     M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far past the expected surface the probe can move before erroring when not triggered." R"MillenniumOS: Probe Outside Corner" T0 S2
     M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status, so you could cause damage if moving in the wrong direction!" R"MillenniumOS: Probe Outside Corner" T0 S2
-    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Outside Corner" S4 K{"Continue", "Cancel"} F0
+    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Outside Corner" S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/outside-corner"">View the Outside Corner Documentation</a> for more details." R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Outside corner probe aborted!" }
     set global.mosDD10 = true

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -35,7 +35,7 @@ if { global.mosTM && !global.mosDD4 }
     M291 P"<b>CAUTION</b>: For X or Y surfaces, the probe will move down <b>BEFORE</b> moving horizontally to detect a surface. Bear this in mind when selecting a starting position." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"For X or Y surfaces, you will then be asked for a <b>probe depth</b>. This is how far your probe will move down from the starting position before moving in X or Y." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"Finally, you will be asked to set a <b>probe distance</b>. This is how far the probe will move towards a surface before returning an error if it did not trigger." R"MillenniumOS: Probe Surface" T0 S2
-    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/single-surfa ce"">View the Single Surface Documentation</a> for more details." R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/single-surface"">View the Single Surface Documentation</a> for more details." R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Surface probe aborted!" }
 

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -34,7 +34,8 @@ if { global.mosTM && !global.mosDD4 }
     M291 P"<b>CAUTION</b>: Jogging in RRF does <b>NOT</b> watch the probe status. Be careful!" R"MillenniumOS: Probe Surface" T0 S2
     M291 P"<b>CAUTION</b>: For X or Y surfaces, the probe will move down <b>BEFORE</b> moving horizontally to detect a surface. Bear this in mind when selecting a starting position." R"MillenniumOS: Probe Surface" T0 S2
     M291 P"For X or Y surfaces, you will then be asked for a <b>probe depth</b>. This is how far your probe will move down from the starting position before moving in X or Y." R"MillenniumOS: Probe Surface" T0 S2
-    M291 P"Finally, you will be asked to set a <b>probe distance</b>. This is how far the probe will move towards a surface before returning an error if it did not trigger." R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+    M291 P"Finally, you will be asked to set a <b>probe distance</b>. This is how far the probe will move towards a surface before returning an error if it did not trigger." R"MillenniumOS: Probe Surface" T0 S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/single-surfa ce"">View the Single Surface Documentation</a> for more details." R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Surface probe aborted!" }
 

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -33,7 +33,8 @@ if { global.mosTM && !global.mosDD11 }
     M291 P"For both modes, you will be asked to enter a <b>clearance distance</b> and an <b>overtravel distance</b>." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"These define how far the probe will move along the surfaces from the corner location before probing, and how far past the expected surface the probe can move before erroring if not triggered." R"MillenniumOS: Probe Vise Corner" T0 S2
     M291 P"You will then jog the tool over the corner to be probed.<br/><b>CAUTION</b>: Jogging in RRF does not watch the probe status - <b>Be Careful!</b>" R"MillenniumOS: Probe Vise Corner" T0 S2
-    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Vise Corner" S4 K{"Continue", "Cancel"} F0
+    M291 P"Finally, you will be asked to select the corner that is being probed, and the depth below the top surface to probe the corner surfaces at, in mm." R"MillenniumOS: Probe Vise Corner" S2
+    M291 P"If you are still unsure, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/vise-corner"">View the Vise Corner Documentation</a> for more details." R"MillenniumOS: Probe Vise Corner" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Vise corner probe aborted!" }
     set global.mosDD11 = true

--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -25,6 +25,9 @@ M598
 ; end up jogging the spindle around while it is running.
 G27 Z1
 
+if { !exists(global.mosLdd) || !global.mosLdd }
+    abort {"MillenniumOS is not loaded! Please restart your mainboard and check for any startup errors!"}
+
 ; Default to null work offset, which will not set origin
 ; on a work offset.
 var workOffset = null

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -68,8 +68,10 @@ else
     ; All other tools cannot be detected so we just have to
     ; trust the operator did the right thing given the
     ; information :)
-    if { global.mosTM }
+    if { global.mosTM && !global.mosDD13 }
         M291 P{"A tool change is required. You will be asked to insert the correct tool, and then the tool length will be probed."} R"MillenniumOS: Tool Change" S2 T0
+        M291 P"If you are unsure about this, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/tool-changes"">View the Tool Change Documentation</a> for more details." R"MillenniumOS: Tool Change" S2 T0
+        set global.mosDD13 = true
 
     ; Prompt user to change tool
     M291 P{"Insert Tool <b>#" ^ state.nextTool ^ "</b>: " ^ tools[state.nextTool].name ^ " and press <b>Continue</b> when ready. <b>Cancel</b> will abort the running job!"} R"MillenniumOS: Tool Change" S4 K{"Continue", "Cancel"}

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -198,7 +198,7 @@ global mosPD = null
 ; displayed during this session. The first 2 indexes
 ; are used by the G6600 macro, the others are used by
 ; G6500 to G6509, one each, in order. G6520 uses mosDD11,
-; and G37.1 uses the last index.
+; and G37.1 uses mosDD12. mosDD13 is used during tool changes.
 global mosDD0 = false
 global mosDD1 = false
 global mosDD2 = false
@@ -212,3 +212,4 @@ global mosDD9 = false
 global mosDD10 = false
 global mosDD11 = false
 global mosDD12 = false
+global mosDD13 = false


### PR DESCRIPTION
Adds links to the relevant documentation at the end of each tutorial-mode probe-cycle description.

Also adds a dismissable tool change message linking to the docs.