### PR TITLE
FreeCAD Post-Processor Improvements

### DIFF
--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -470,11 +470,12 @@ class MillenniumOSPostProcessor(PostProcessor):
             Output(prefix='X', fmt=FORMATS.AXES),
             Output(prefix='Y', fmt=FORMATS.AXES),
             Output(prefix='Z', fmt=FORMATS.AXES),
-            Output(prefix='I', fmt=FORMATS.AXES, ctrl=Control.NONZERO),
-            Output(prefix='J', fmt=FORMATS.AXES, ctrl=Control.NONZERO),
-            Output(prefix='K', fmt=FORMATS.AXES, ctrl=Control.NONZERO),
-            Output(prefix='F', fmt=FORMATS.FEED, ctrl=Control.NONZERO),
-            Output(prefix='R', fmt=FORMATS.STR),
+            Output(prefix='I', fmt=FORMATS.AXES, ctrl=Control.FORCE),
+            Output(prefix='J', fmt=FORMATS.AXES, ctrl=Control.FORCE),
+            Output(prefix='K', fmt=FORMATS.AXES, ctrl=Control.FORCE),
+            Output(prefix='R', fmt=FORMATS.AXES, ctrl=Control.FORCE),
+            Output(prefix='F', fmt=FORMATS.FEED, ctrl=Control.FORCE),
+            Output(prefix='R', typ=str, fmt=FORMATS.STR),
             Output(prefix='W', fmt=FORMATS.WCS)
         ], ctrl=Control.FORCE)
 

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -20,7 +20,6 @@
 # - It is the responsibility of your macros and firmware to run any safety checks.
 
 import sys
-import pprint
 import argparse
 import shlex
 import re
@@ -765,9 +764,7 @@ class MillenniumOSPostProcessor(PostProcessor):
         params = {}
 
         for pkey, pvalue in cmd.Parameters.items():
-            v = self._parseparam(code, pkey, pvalue)
-            if v:
-                params[pkey] = v
+            params[pkey] = self._parseparam(code, pkey, pvalue)
 
         match ctype:
             case 'G':


### PR DESCRIPTION
- Make sure `I`, `J`, `K` and `R` parameters for arc moves output correctly. These are now reset when encountering a linear move, and vice versa for arc moves on linear move parameters.
- Try to error when post-processing an operation without the spindle being started. If using a drag-knife or similar tool that requires the spindle to not be running, you can pass `--allow-zero-rpm` to the post-processor to disable this safety check.
- Delay `Z` moves that occur before the first `X`/`Y` move in an operation - we want to move over the starting point first and then down to the clearance height rather than the FreeCAD behaviour of moving in `Z` first.