### PR TITLE
Make sure M3.9 is called using M98

### DIFF
--- a/macro/movement/G27.g
+++ b/macro/movement/G27.g
@@ -23,7 +23,7 @@ G94
 G53 G0 Z{move.axes[2].max}
 
 ; Stop spindle and wait
-M5.9
+M98 P"M5.9.g"
 
 ; If park is called with Z parameter, then the table itself will not be
 ; moved.

--- a/sys/resume.g
+++ b/sys/resume.g
@@ -12,7 +12,9 @@ if { state.currentTool >= 0 && state.currentTool < limits.tools}
     if { tools[state.currentTool].spindleRpm > 0 }
         ; Restore spindle speed from before the pause
         ; TODO: What about spindle direction?
-        M3.9 S{ tools[state.currentTool].spindleRpm }
+
+        ; Stop spindle and wait
+        M98 P"M3.9.g" S{ tools[state.currentTool].spindleRpm }
 
 ; Move to X/Y position above the stored co-ordinates
 ; This will occur at machine Z=0 as we parked the


### PR DESCRIPTION
Until the differences between calling a macro directly and using `M98` are cleared up, we should call `M3.9` and `M5.9` using `M98` rather than directly.