### PR TITLE
Fix unbracketed expression in G6500.1

### DIFF
--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -69,7 +69,7 @@ var sZ   = { param.L }
 
 ; Calculate probing directions using approximate bore radius
 ; Angle is in degrees
-var angle = radians(120)
+var angle = { radians(120) }
 
 var dirXY = { { var.sX + var.bR, var.sY}, { var.sX + var.bR * cos(var.angle), var.sY + var.bR * sin(var.angle) }, { var.sX + var.bR * cos(2 * var.angle), var.sY + var.bR * sin(2 * var.angle) } }
 


### PR DESCRIPTION
Looks like nobody tested the bore probe function after moving this to a variable, RRF functions need to be inside an expression.