### PR TITLE
Do not output G99 from FreeCAD drill cycles

### DIFF
--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -493,7 +493,7 @@ class MillenniumOSPostProcessor(PostProcessor):
     _TOOL_CHANGES          = [6]
     _WCS_CHANGES           = [54, 55, 56, 57, 58, 59, 59.1, 59.2, 59.3]
     _CANNED_CYCLES         = [73, 81, 83]
-    _UNSUPPORTED           = [98]
+    _UNSUPPORTED           = [98, 99]
 
     # Define command output formatters
     _G   = Output(fmt=FORMATS.CMD, prefix='G', vars = [


### PR DESCRIPTION
`G99` isn't supported by RRF and isn't necessary for how our drilling cycles are implemented.