### PR TITLE
Fix probes not throwing errors when deactivated

### DIFF
--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -23,8 +23,9 @@ if { !exists(param.X) && !exists(param.Y) && !exists(param.Z) }
 ; Allow the number of retries to be overridden
 var retries = { (exists(param.R) && param.R != null) ? param.R : sensors.probes[param.I].maxProbeCount }
 
-; Errors
-var errors = { !exists(param.E) || param.E == 1 }
+; Whether to throw an error if the probe is not activated
+; when it reaches the target position.
+var errors = { !exists(param.E) || param.E != 0 }
 
 ; Use absolute positions in mm and feeds in mm/min
 G90

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -141,7 +141,7 @@ G6550 I{ exists(param.I) ? param.I : null } Z{ var.sZ }
 if { var.manualProbe }
     G6512.2 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 else
-    G6512.1 I{ param.I } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ } R{ exists(param.R) ? param.R : null } E{ exists(param.E) ? param.E : null }
+    G6512.1 I{ param.I } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ } R{ exists(param.R) ? param.R : null } E{ exists(param.E) ? param.E : 1 }
 
 ; Move to safe height
 ; If probing move is called with D parameter,


### PR DESCRIPTION
Probe cycles would continue attempting to probe if a probe point was not activated - this was down to the 'errors' functionality added to support radius offset tool probing.

When the `E` param was not specified, `null` would be passed to the underlying probing macro - but we were using `if(!exists(param.E))` to validate this.

Passing `Enull` to RRF means that `param.E` _exists_, so that check does not correctly turn on errors.

We fix this by making the following check `param.E != 0`, so we only disable errors if the parameter is specifically 0. Then we _also_ pass `1` in all cases where `param.E` was not given by the higher-level probing macro.