### PR TITLE
Fix VSSC errors when no tool selected

### DIFF
--- a/macro/private/run-vssc.g
+++ b/macro/private/run-vssc.g
@@ -54,7 +54,8 @@ else
     ; time since the last adjustment.
     var adjustedSpindleRPM = { ceil(var.lowerLimit + global.mosVSV * ((sin(2 * pi * var.elapsedTime / global.mosVSP) + 1) / 2)) }
 
-    ; Set adjusted spindle RPM
-    if { global.mosDebug }
-        echo {"[VSSC] Adjusted spindle RPM: " ^ var.adjustedSpindleRPM }
-    M568 F{ var.adjustedSpindleRPM }
+    if { state.currentTool >= 0 }
+        ; Set adjusted spindle RPM
+        if { global.mosDebug }
+            echo {"[VSSC] Adjusted spindle RPM: " ^ var.adjustedSpindleRPM }
+        M568 F{ var.adjustedSpindleRPM }


### PR DESCRIPTION
When controlling the spindle manually via DWC with VSSC activated, errors would be thrown every cycle of the daemon if no tool was selected.

We now do not attempt to set the spindle RPM if no tool is selected. This is necessary because of how we control the spindle speed based on the tool speed.