### PR TITLE
Various fixes and updates

### DIFF
--- a/macro/machine/M3000.g
+++ b/macro/machine/M3000.g
@@ -14,19 +14,19 @@ if { !inputs[state.thisInput].active }
 if { !exists(param.S) || !exists(param.R) }
     abort { "Must provide dialog title (R""..."") and message (S""..."")!" }
 
-var options = null
+; Do not render dialog during resume, pause or pausing
+if { state.status == "resuming" || state.status == "pausing" || state.status == "paused" }
+    M99
 
 ; Provide a pause option if the machine is running a job and not currently paused
-if { job.file.fileName != null && (state.status != "resuming" && state.status != "pausing" && state.status != "paused") }
-    set var.options = { "Continue", "Pause", "Cancel" }
+if { job.file.fileName != null }
+    M291 P{param.S} R{"MillenniumOS: " ^ param.R} S4 K{"Continue", "Pause", "Cancel"} F0
+    if { input > 1 }
+        abort { "Operator cancelled job." }
 else
-    set var.options = { "Continue", "Cancel" }
-
-M291 P{param.S} R{"MillenniumOS: " ^ param.R} S4 K{var.options} F0
-
-; If input is the last option in the list, then abort
-if { (input+1) == #var.options }
-    abort { "Operator cancelled job." }
+    M291 P{param.S} R{"MillenniumOS: " ^ param.R} S4 K{"Continue", "Cancel"} F0
+    if { input > 0 }
+        abort { "Operator cancelled job." }
 
 ; Otherwise if input is not the first option,
 ; then the operator clicked pause.

--- a/macro/movement/G27.g
+++ b/macro/movement/G27.g
@@ -11,9 +11,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Use absolute positions in mm
 G90
 G21

--- a/macro/movement/G37.1.g
+++ b/macro/movement/G37.1.g
@@ -21,9 +21,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 var wPN = { move.workplaceNumber + 1 }
 
 if { global.mosTM && !global.mosDD12 }

--- a/macro/movement/G37.g
+++ b/macro/movement/G37.g
@@ -33,9 +33,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Without a toolsetter, the operator will have to zero the tool themselves.
 if { ! global.mosFeatToolSetter }
     abort { "Tool length probing without a toolsetter is not currently supported!" }

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -17,9 +17,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6500.g
+++ b/macro/movement/G6500.g
@@ -12,9 +12,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of bore probe if not already displayed this session
 if { global.mosTM && !global.mosDD2 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular bore (hole) in a workpiece by moving downwards into the bore and probing outwards in 3 directions." R"MillenniumOS: Probe Bore" T0 S2

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -16,9 +16,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6501.g
+++ b/macro/movement/G6501.g
@@ -12,9 +12,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of boss probe if not already displayed this session
 if { global.mosTM && !global.mosDD3 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a circular boss (protruding feature) on a workpiece by probing towards the approximate center of the boss in 3 directions." R"MillenniumOS: Probe Boss" T0 S2

--- a/macro/movement/G6502.1.g
+++ b/macro/movement/G6502.1.g
@@ -8,9 +8,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -13,9 +13,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of rectangle pocket probe if not already displayed this session
 if { global.mosTM && !global.mosDD6 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a rectangular pocket (recessed feature) on a workpiece by moving into the pocket and probing towards each surface." R"MillenniumOS: Probe Rect. Pocket " T0 S2

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -8,9 +8,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -13,9 +13,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of rectangle block probe if not already displayed this session
 if { global.mosTM && !global.mosDD5 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the center of a rectangular block (protruding feature) on a workpiece by probing towards the block surfaces from all 4 directions." R"MillenniumOS: Probe Rect. Block " T0 S2

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -7,9 +7,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 
@@ -249,6 +246,12 @@ if { var.pMO == 0 }
     ; this stays a positive value less than 180 (ideally around 90).
     var diff = { abs(degrees(var.aX - var.aY)) }
     set global.mosWPCnrDeg = { mod(var.diff + 360, 180) }
+
+    ; If running in full mode, operator provided approximate width and
+    ; height values of the workpiece. Assign these to the global
+    ; variables for the workpiece width and height.
+    ; This assumes that the workpiece is rectangular.
+    set global.mosWPDims = { var.fX, var.fY }
 
 else
     ; Calculate corner position in quick mode.

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -20,9 +20,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of rectangle block probe if not already displayed this session
 if { global.mosTM && !global.mosDD10 }
     M291 P"This probe cycle finds the X and Y co-ordinates of the corner of a rectangular workpiece by probing along the 2 edges that form the corner." R"MillenniumOS: Probe Outside Corner " T0 S2

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -8,9 +8,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -12,9 +12,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Friendly names to indicate the location of a surface to be probed, relative to the tool.
 ; Left means 'surface is to the left of the tool', i.e. we will move the table towards the
 ; _right_ to probe it.

--- a/macro/movement/G6511.g
+++ b/macro/movement/G6511.g
@@ -17,9 +17,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 G90
 G21
 G94

--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -11,9 +11,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { !exists(param.I) || param.I == null || sensors.probes[param.I].type < 5 || sensors.probes[param.I].type > 8 }
     abort { "G6512.1: Must provide a valid probe ID (I..)!" }
 

--- a/macro/movement/G6512.2.g
+++ b/macro/movement/G6512.2.g
@@ -10,9 +10,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { !exists(param.X) && !exists(param.Y) && !exists(param.Z) }
     abort { "G6512: Must provide a valid target position in one or more axes (X.. Y.. Z..)!" }
 

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -60,9 +60,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.I) && param.I != null && (sensors.probes[param.I].type < 5 || sensors.probes[param.I].type > 8) }
     abort { "G6512: Invalid probe ID (I..), probe must be of type 5 or 8, or unset for manual probing." }
 

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -16,9 +16,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.W) && param.W != null && (param.W < 1 || param.W > limits.workplaces) }
     abort { "WCS number (W..) must be between 1 and " ^ limits.workplaces ^ "!" }
 

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -21,9 +21,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Display description of vise corner probe if not already displayed this session
 if { global.mosTM && !global.mosDD11 }
     M291 P"This probe cycle finds the X, Y and Z co-ordinates of the corner of a workpiece by probing the top surface and each of the edges that form the corner." R"MillenniumOS: Probe Vise Corner" T0 S2

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -28,9 +28,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 if { exists(param.I) && param.I != null && (sensors.probes[param.I].type < 5 || sensors.probes[param.I].type > 8) }
     abort { "G6550: Invalid probe ID (I..), probe must be of type 5 or 8, or unset for manual probing." }
 

--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -15,9 +15,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; This is just for safety. It is good practice to park the machine and
 ; stop the spindle before calling any probing macro, and we should do
 ; this in any post-processor that targets the MillenniumOS Gcode Dialect,

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -9,9 +9,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 var wizUVF = "mos-user-vars.g"
 var wizTVF = "mos-resume-vars.g"
 

--- a/macro/private/run-vssc.g
+++ b/macro/private/run-vssc.g
@@ -54,7 +54,8 @@ else
     ; time since the last adjustment.
     var adjustedSpindleRPM = { ceil(var.lowerLimit + global.mosVSV * ((sin(2 * pi * var.elapsedTime / global.mosVSP) + 1) / 2)) }
 
-    ; Set adjusted spindle RPM
-    if { global.mosDebug }
-        echo {"[VSSC] Adjusted spindle RPM: " ^ var.adjustedSpindleRPM }
-    M568 F{ var.adjustedSpindleRPM }
+    if { state.currentTool >= 0 }
+        ; Set adjusted spindle RPM
+        if { global.mosDebug }
+            echo {"[VSSC] Adjusted spindle RPM: " ^ var.adjustedSpindleRPM }
+        M568 F{ var.adjustedSpindleRPM }

--- a/macro/tool-change/tfree.g
+++ b/macro/tool-change/tfree.g
@@ -7,9 +7,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Set tool change state to starting tfree
 set global.mosTCS = 0
 

--- a/macro/tool-change/tpost.g
+++ b/macro/tool-change/tpost.g
@@ -8,9 +8,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Abort if no tool selected
 if { state.currentTool < 0 }
     M99

--- a/macro/tool-change/tpre.g
+++ b/macro/tool-change/tpre.g
@@ -12,9 +12,6 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Make sure we're in the default motion system
-M598
-
 ; Abort if no tool selected
 if { state.nextTool < 0 }
     M99
@@ -70,6 +67,13 @@ else
     ; information :)
     if { global.mosTM && !global.mosDD13 }
         M291 P{"A tool change is required. You will be asked to insert the correct tool, and then the tool length will be probed."} R"MillenniumOS: Tool Change" S2 T0
+
+        if { global.mosFeatToolSetter && global.mosTT[state.nextTool][0] > global.mosTSR }
+            var dH = sensors.probes[global.mosTSID].diveHeights[0]
+            M291 P"The next tool is bigger than your toolsetter, so we need to perform offset radius probing. We will probe the center of the tool once, then probe around the radius to detect the lowest point." R"MillenniumOS: Tool Change" S2 T0
+            M291 P"Please ensure the center of the tool is no higher than " ^ var.dH ^ "mm from the lowest point, and adjust the <b>dive height</b> of your toolsetter (<b>M558 H...</b> in RRF) if so." R"MillenniumOS: Tool Change" S2 T0
+            M291 P"You can read more about how radius offset probing works <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/radius-offset-probing"">here</a>." R"MillenniumOS: Tool Change" S2 T0
+
         M291 P"If you are unsure about this, you can <a target=""_blank"" href=""https://mos.diycnc.xyz/usage/tool-changes"">View the Tool Change Documentation</a> for more details." R"MillenniumOS: Tool Change" S2 T0
         set global.mosDD13 = true
 

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -120,10 +120,11 @@ global mosWPCnrPos = { null, null }
 global mosWPCnrDeg = { null, null }
 
 ; This is the Co-ordinate along the chosen axis of the
-; most recent single surface probe
+; most recent single surface probe.
 global mosWPSfcPos = null
 
-; This is the axis along which the most recent single
+; This is the axis of the measurement of the most recent
+; single surface probe.
 global mosWPSfcAxis = null
 
 ; Canned Cycle settings


### PR DESCRIPTION
* Remove all calls to `M598` as this is no longer needed given the changes released as part of `3.5.0` - multiple motion systems are now no longer activated by default.
* Add message to `tpre.g` when radius probing will be used.
* Change how `M3000` responds to pause / resume behaviour.