### PR TITLE
Fix intermittent HardFault Unaligned on null

### DIFF
--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -35,16 +35,10 @@ set global.mosTT[param.P][0] = { param.R }
 ; when used for probing. This does not need to be set for
 ; non-probe tools.
 if { exists(param.X) }
-    if { global.mosTT[param.P][1] == null }
-        set global.mosTT[param.P][1] = { param.X, 0.0 }
-    else
-        set global.mosTT[param.P][1][0] = { param.X }
+    set global.mosTT[param.P][1][0] = { param.X }
 
 if { exists(param.Y) }
-    if { global.mosTT[param.P][1] == null }
-        set global.mosTT[param.P][1] = { 0.0, param.Y }
-    else
-        set global.mosTT[param.P][1][1] = { param.Y }
+    set global.mosTT[param.P][1][1] = { param.Y }
 
 ; Commented due to memory limitations
 ; M7500 S{"Stored tool #" ^ param.P ^ " R=" ^ param.R ^ " S=" ^ param.S}

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -175,7 +175,7 @@ var mag = { sqrt(pow(var.tPX - var.sX, 2) + pow(var.tPY - var.sY, 2)) }
 if { var.mag != 0 }
     ; Adjust the final position along the direction of movement in X and Y
     ; by the tool radius, subtracting the deflection on each axis.
-    set global.mosPCX = { global.mosPCX + (global.mosTT[state.currentTool][0] - global.mosTT[state.currentTool[1][0]) * ((var.tPX - var.sX) / var.mag) }
+    set global.mosPCX = { global.mosPCX + (global.mosTT[state.currentTool][0] - global.mosTT[state.currentTool][1][0]) * ((var.tPX - var.sX) / var.mag) }
     set global.mosPCY = { global.mosPCY + (global.mosTT[state.currentTool][0] - global.mosTT[state.currentTool][1][1]) * ((var.tPY - var.sY) / var.mag) }
 
 ; We do not adjust by the tool radius in Z.

--- a/macro/movement/G6512.g
+++ b/macro/movement/G6512.g
@@ -173,12 +173,10 @@ var mag = { sqrt(pow(var.tPX - var.sX, 2) + pow(var.tPY - var.sY, 2)) }
 
 ; Only compensate for the tool radius if the probe has moved in the relevant axes.
 if { var.mag != 0 }
-    ; Tool deflection in X and Y, if set.
-    var dD = { (global.mosTT[state.currentTool][1] == null) ? { 0.0, 0.0 } : global.mosTT[state.currentTool][1] }
-
-    ; Adjust the final position along the direction of movement in X and Y by the tool radius.
-    set global.mosPCX = { global.mosPCX + (global.mosTT[state.currentTool][0] - var.dD[0]) * ((var.tPX - var.sX) / var.mag) }
-    set global.mosPCY = { global.mosPCY + (global.mosTT[state.currentTool][0] - var.dD[1]) * ((var.tPY - var.sY) / var.mag) }
+    ; Adjust the final position along the direction of movement in X and Y
+    ; by the tool radius, subtracting the deflection on each axis.
+    set global.mosPCX = { global.mosPCX + (global.mosTT[state.currentTool][0] - global.mosTT[state.currentTool[1][0]) * ((var.tPX - var.sX) / var.mag) }
+    set global.mosPCY = { global.mosPCY + (global.mosTT[state.currentTool][0] - global.mosTT[state.currentTool][1][1]) * ((var.tPY - var.sY) / var.mag) }
 
 ; We do not adjust by the tool radius in Z.
 

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -30,7 +30,7 @@ global mosCnr = {"Front Left", "Front Right", "Back Right", "Back Left"}
 
 ; Store additional tool information.
 ; Values are: [radius, {deflection-x, deflection-y}]
-global mosET = { 0.0, null }
+global mosET = { 0.0, {0.0, 0.0} }
 global mosTT = { vector(limits.tools, global.mosET) }
 
 ; State of current tool change operation.


### PR DESCRIPTION
We were previously defaulting the deflection value to `null` in the tool table - but this appears to take up half as much space as the actual value, which ends up being 2 floats. In certain situations this would cause a HardFault Unaligned and bootloop the mainboard.

By not using `null` as the default value, we should avoid overflowing the tool table and boot as normal.