### PR TITLE
Implement MillenniumOS version check against posts

### DIFF
--- a/macro/machine/M4005.g
+++ b/macro/machine/M4005.g
@@ -1,0 +1,7 @@
+; M4005.g: Check MillenniumOS Post Version
+
+if { !exists(param.V) }
+    abort { "Must pass post-processor version (V...)"}
+
+if { param.V != global.mosVer }
+    abort { "MillenniumOS: Post-processor version " ^ param.V ^ " does not match installed version " ^ global.mosVer ^ "!" }

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# Millenium Machines Milo v1.5 Postprocessor for FreeCAD.
+# MillenniumOS %%MOS_VERSION%% Postprocessor for FreeCAD.
 #
-# Copyright (C)2022-2023 Millenium Machines
+# Copyright (C)2022-2024 Millennium Machines
 #
-# This postprocessor assumes that most complex functionality like
+# This post-processor assumes that most complex functionality like
 # tool changes and work coordinate setting is handled in the machine firmware.
 #
 # Calls in to these systems should be a single macro call, preferably using a custom

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -66,11 +66,12 @@ class GCODES:
     PROBE_VISE_CORNER       = 6520.1
 
 class MCODES:
-    CALL_MACRO   = 98
-    ADD_TOOL     = 4000
-    VSSC_ENABLE  = 7000
-    VSSC_DISABLE = 7001
-    SHOW_DIALOG  = 3000
+    CALL_MACRO    = 98
+    ADD_TOOL      = 4000
+    VERSION_CHECK = 4005
+    VSSC_ENABLE   = 7000
+    VSSC_DISABLE  = 7001
+    SHOW_DIALOG   = 3000
 
 # Define format strings for variable and command types
 class FORMATS:
@@ -147,6 +148,12 @@ parser.add_argument('--allow-zero-rpm', action=argparse.BooleanOptionalAction, d
     be left disabled for normal milling operations.
     """)
 
+parser.add_argument('--version-check', action=argparse.BooleanOptionalAction, default=True,
+    help="""
+    When enabled, the post-processor will output a version check command
+    to make sure the post-processor version and MillenniumOS version installed
+    in RRF match.
+    """)
 probe_mode = parser.add_mutually_exclusive_group(required=False)
 probe_mode.add_argument('--probe-at-start', dest='probe_mode', action='store_const', const=PROBE.AT_START,
     help="When enabled, MillenniumOS will probe a work-piece in each used WCS prior to executing any operations.")
@@ -520,7 +527,8 @@ class MillenniumOSPostProcessor(PostProcessor):
             Output(prefix='S', typ=str, fmt=FORMATS.STR, ctrl=Control.FORCE),
             # This acts as default output for S if it does not match the
             # type specified above.
-            Output(prefix='S', fmt=FORMATS.RPM, ctrl=Control.FORCE)
+            Output(prefix='S', fmt=FORMATS.RPM, ctrl=Control.FORCE),
+            Output(prefix='V', typ=str, fmt=FORMATS.STR, ctrl=Control.FORCE),
         ], ctrl=Control.FORCE)
 
     _T   = Output(fmt=FORMATS.CMD, prefix='T', ctrl=Control.FORCE)
@@ -834,6 +842,10 @@ class MillenniumOSPostProcessor(PostProcessor):
     def output(self):
         with self.Section(Section.PRE):
             self.comment("Begin preamble")
+
+            self.brk()
+            self.comment("Check MillenniumOS version matches post-processor version")
+            self.M(MCODES.VERSION_CHECK, V=RELEASE.VERSION, ctrl=Control.FORCE)
 
             # Parsing must be completed to enumerate all tools.
             tools = self.toolinfo()

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -1,7 +1,7 @@
 /**
- * MillenniumOS v1.0 Postprocessor for Fusion360.
+ * MillenniumOS %%MOS_VERSION%% Postprocessor for Fusion360.
  *
- * This postprocessor assumes that most complex functionality like
+ * This post-processor assumes that most complex functionality like
  * tool changes and work coordinate setting is handled in the machine firmware.
  *
  * Calls in to these systems should be a single macro call, preferably using a custom
@@ -419,13 +419,7 @@ function onOpen() {
   // Output header and preamble
   writeComment("Exported by Fusion360");
 
-  var version = "Unknown";
-  if ((typeof getHeaderVersion) == "function" && getHeaderVersion()) {
-    version = getHeaderVersion();
-  }
-  if ((typeof getHeaderDate) == "function" && getHeaderDate()) {
-    version += " " + getHeaderDate();
-  }
+  var version = "%%MOS_VERSION%%";
 
   // Write post-processor and generation details.
   writeComment("Post Processor: {desc} by {vendor}, version: {version}".supplant({desc: description, vendor: vendor, version: version }));

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -136,6 +136,14 @@ properties = {
     type: "boolean",
     value: true
   },
+  versionCheck: {
+    title: "Check MillenniumOS version",
+    description: "Check that the MillenniumOS version installed in RRF matches the post-processor version. Undefined behaviour may occur if this check is disabled and the firmware is not compatible with this post-processor.",
+    group: "formats",
+    scope: "post",
+    type: "boolean",
+    value: true
+  },
   warpSpeedMode: {
     title: "Restore rapid moves at and above the selected height",
     description: "The operation height above which G0 moves will be restored. Only vertical OR lateral moves are considered. None disables warp mode. Retract and Clearance restore rapid moves at and above the relevant height set on the operation. Zero restores all rapid moves at or above Z=0 in the active WCS. BEWARE: Be absolutely certain when using Zero mode that your tool offsets are calculated accurately, as rapid moves back down to Z=0 will not allow any leeway for tool length errors! Additionally, only use Zero if you can guarantee there is nothing above Z=0 that could interfere with rapid moves.",
@@ -283,6 +291,7 @@ var G = {
 // Define M code constants for non-standard codes.
 var M = {
   ADD_TOOL: 4000,
+  VERSION_CHECK: 4005,
   VSSC_ENABLE: 7000,
   VSSC_DISABLE: 7001,
   SPINDLE_ON_CW: 3.9,
@@ -352,6 +361,7 @@ var mCodes = createModalGroup(
   [
     [0, 2],                           // Program codes
     [M.ADD_TOOL],                     // Tool data codes
+    [M.VERSION_CHECK],                // Version check
     [M.VSSC_ENABLE, M.VSSC_DISABLE]   // VSSC codes
   ],
   mFmt);
@@ -429,6 +439,12 @@ function onOpen() {
   writeln("");
   writeComment("Begin preamble");
   writeln("");
+
+  if(properties.versionCheck) {
+    writeComment("Check MillenniumOS version matches post-processor version");
+    writeBlock(mCodes.format(M.VERSION_CHECK), 'V"{version}"'.supplant({version: version}));
+    writeln("");
+  }
 
   // Output tool details if enabled and tools are configured
   var tools  = getToolTable();


### PR DESCRIPTION
Expose a setting in each post-processor that is enabled by default, and outputs `M4005 V"<post-version>"` into the preamble. The version passed to `M4005` is compared against the stored version of MillenniumOS on the machine, and jobs will be aborted at the start if the version numbers do not match.