### PR TITLE
Implement Spindle Feedback Delays

### DIFF
--- a/macro/machine/M3.9.g
+++ b/macro/machine/M3.9.g
@@ -112,26 +112,24 @@ var alreadyWaited = false
 if { global.mosFeatSpindleFeedback }
     if { var.sStopping && global.mosSFSID != null }
         if { !global.mosEM }
-            echo { "Waiting for spindle #" ^ var.sID ^ " to stop based on feedback pin " ^ global.mosSFSID }
+            echo { "MillenniumOS: Waiting for spindle #" ^ var.sID ^ " to stop" }
 
         ; Wait for Spindle Feedback input to change state.
         ; Wait a maximum of 30 seconds, or abort.
         M8004 K{global.mosSFSID} D100 W30
         set var.alreadyWaited = true
-        echo {"Spindle #" ^ var.sID ^ " has stopped based on feedback pin " ^ global.mosSFSID }
 
     elif { global.mosSFCID != null }
         if { !global.mosEM }
-            echo { "Waiting for spindle #" ^ var.sID ^ " to reach target speed based on feedback pin " ^ global.mosSFCID }
+            echo { "MillenniumOS: Waiting for spindle #" ^ var.sID ^ " to reach the target speed" }
 
         ; Wait for Spindle Feedback input to change state.
         ; Wait a maximum of 30 seconds, or abort.
         M8004 K{global.mosSFCID} D100 W30
         set var.alreadyWaited = true
-        echo { "Spindle #" ^ var.sID ^ " has reached target speed based on feedback pin " ^ global.mosSFCID }
 
 if { !var.alreadyWaited }
     if { var.dwellTime > 0 }
         if { !global.mosEM }
-            echo { "Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to change speed" }
+            echo { "MillenniumOS: Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to reach the target speed" }
         G4 S{var.dwellTime}

--- a/macro/machine/M3.9.g
+++ b/macro/machine/M3.9.g
@@ -12,20 +12,27 @@
 if { !inputs[state.thisInput].active }
     M99
 
+; Validate Spindle ID parameter
 if { exists(param.P) && param.P < 0 }
     abort { "Spindle ID must be a positive value!" }
 
-; Allocate spindle ID
+; Allocate Spindle ID
 var sID = { (exists(param.P) ? param.P : global.mosSID) }
 
+; Validate Spindle Speed parameter
 if { exists(param.S) }
     if { param.S < 0 }
-        abort { "Spindle speed must be a positive value!" }
+        abort { "Spindle speed for spindle #" ^ var.sID ^ " must be a positive value!" }
+
     if { param.S > spindles[var.sID].max }
         abort { "Spindle speed " ^ param.S ^ " exceeds maximum configured speed " ^ spindles[var.sID].max ^ " on spindle #" ^ var.sID ^ "!" }
 
+; Validate Dwell Time override parameter
 if { exists(param.D) && param.D < 0 }
     abort { "Dwell time must be a positive value!" }
+
+; True if spindle is stopping
+var sStopping = { spindles[var.sID].current > 0 && param.S == 0 }
 
 ; Warning Message for Operator
 var wM = {"<b>CAUTION</b>: Spindle <b>#" ^ var.sID ^ "</b> will now start!<br/>Check that workpiece and tool are secure, and all safety precautions have been taken before pressing <b>Continue</b>."}
@@ -53,29 +60,32 @@ if { spindles[var.sID].current == 0 }
         if { input == 1 }
             abort { "Operator aborted spindle startup!" }
 
-; Must calculate dwell time before spindle speed is changed.
 
 ; Dwell time defaults to the previously timed spindle acceleration time.
-; This assumes the spindle is accelerating from a stop.
-var dT = { global.mosSAS }
+; If using spindle feedback, this will likely be a null value and is
+; unused anyway.
 
+; This assumes the spindle is accelerating from a stop.
+var dwellTime = { global.mosSAS }
+
+; Must calculate dwell time before spindle speed is changed.
 ; D parameter always overrides the dwell time
 if { exists(param.D) }
-    set var.dT = { param.D }
+    set var.dwellTime = { param.D }
 else
     ; If we're changing spindle speed
     if { exists(param.S) }
 
-        ; If this is a deceleration, adjust dT
+        ; If this is a deceleration, adjust dT to use the deceleration timer
         if { spindles[var.sID].current > param.S }
-            set var.dT = { global.mosSDS }
+            set var.dwellTime = { global.mosSDS }
 
         ; Now calculate the change in velocity as a percentage
         ; of the maximum spindle speed, and multiply the dwell time
         ; by that percentage with 5% extra leeway.
         ; Ceil this so we always wait a round second, no point waiting
         ; less than 1 anyway.
-        set var.dT = { ceil(var.dT * (abs(spindles[var.sID].current - param.S) / spindles[var.sID].max) * 1.05) }
+        set var.dwellTime = { ceil(var.dwellTime * (abs(spindles[var.sID].current - param.S) / spindles[var.sID].max) * 1.05) }
 
 ; All safety checks have now been passed, so we can
 ; start the spindle using M3 here.
@@ -95,10 +105,33 @@ else
 if { result != 0 }
     abort { "Failed to control Spindle ID " ^ var.sID ^ "!" }
 
-; Wait for the spindle to change speed, if necessary,
-; and display a message indicating why we're waiting
-; if expert mode is turned off.
-if { var.dT > 0 }
-    if { !global.mosEM }
-        echo { "Waiting " ^ var.dT ^ " seconds for spindle #" ^ var.sID ^ " to change speed" }
-    G4 S{var.dT}
+; If spindle feedback is enabled, then wait using the correct pin if it
+; is defined, for speed changes or stopping.
+var alreadyWaited = false
+
+if { global.mosFeatSpindleFeedback }
+    if { var.sStopping && global.mosSFSID != null }
+        if { !global.mosEM }
+            echo { "Waiting for spindle #" ^ var.sID ^ " to stop based on feedback pin " ^ global.mosSFSID }
+
+        ; Wait for Spindle Feedback input to change state.
+        ; Wait a maximum of 30 seconds, or abort.
+        M8004 K{global.mosSFSID} D100 W30
+        set var.alreadyWaited = true
+        echo {"Spindle #" ^ var.sID ^ " has stopped based on feedback pin " ^ global.mosSFSID }
+
+    elif { global.mosSFCID != null }
+        if { !global.mosEM }
+            echo { "Waiting for spindle #" ^ var.sID ^ " to reach target speed based on feedback pin " ^ global.mosSFCID }
+
+        ; Wait for Spindle Feedback input to change state.
+        ; Wait a maximum of 30 seconds, or abort.
+        M8004 K{global.mosSFCID} D100 W30
+        set var.alreadyWaited = true
+        echo { "Spindle #" ^ var.sID ^ " has reached target speed based on feedback pin " ^ global.mosSFCID }
+
+if { !var.alreadyWaited }
+    if { var.dwellTime > 0 }
+        if { !global.mosEM }
+            echo { "Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to change speed" }
+        G4 S{var.dwellTime}

--- a/macro/machine/M5.9.g
+++ b/macro/machine/M5.9.g
@@ -26,7 +26,7 @@ if { exists(param.D) && param.D < 0 }
 var sID = { global.mosSID }
 var doWait = false
 
-while { (iterations < #spindles) && !var.dW }
+while { (iterations < #spindles) && !var.doWait }
     set var.doWait = { spindles[iterations].current != 0 }
     ; In case M5.9 should stop a spindle that _isnt_ the one
     ; configured in MOS. We'll calculate the delay time based
@@ -50,7 +50,7 @@ elif { var.doWait }
     ; by that percentage with 5% extra leeway.
     ; Ceil this so we always wait a round second, no point waiting
     ; less than 1 anyway.
-    set var.dwellTime = { ceil(var.dT * (abs(spindles[var.sID].current) / spindles[var.sID].max) * 1.05) }
+    set var.dwellTime = { ceil(var.dwellTime * (abs(spindles[var.sID].current) / spindles[var.sID].max) * 1.05) }
 
 ; We run M5 unconditionally for safety purposes. If
 ; the object model is not up to date for whatever
@@ -65,14 +65,13 @@ if { !var.doWait }
 
 if { global.mosFeatSpindleFeedback && global.mosSFSID != null }
     if { !global.mosEM }
-        echo { "Waiting for spindle #" ^ var.sID ^ " to stop based on feedback pin " ^ global.mosSFSID }
+        echo { "MillenniumOS: Waiting for spindle #" ^ var.sID ^ " to stop" }
     ; Wait for Spindle Feedback input to change state.
     ; Wait a maximum of 30 seconds, or abort.
     M8004 K{global.mosSFSID} D100 W30
-    echo { "Spindle #" ^ var.sID ^ " has stopped based on feedback pin " ^ global.mosSFSID }
 
-; Otherwise wait for spindle to stop manually
 elif { var.dwellTime > 0 }
+    ; Otherwise wait for spindle to stop manually
     if { !global.mosEM }
-        echo { "Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to stop" }
+        echo { "MillenniumOS: Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to stop" }
     G4 S{var.dwellTime}

--- a/macro/machine/M5.9.g
+++ b/macro/machine/M5.9.g
@@ -24,10 +24,10 @@ if { exists(param.D) && param.D < 0 }
 ; for this first and only trigger a wait if any spindles are
 ; activated.
 var sID = { global.mosSID }
-var dW = false
+var doWait = false
 
 while { (iterations < #spindles) && !var.dW }
-    set var.dW = { spindles[iterations].current != 0 }
+    set var.doWait = { spindles[iterations].current != 0 }
     ; In case M5.9 should stop a spindle that _isnt_ the one
     ; configured in MOS. We'll calculate the delay time based
     ; on the spindle that is actually running.
@@ -36,21 +36,21 @@ while { (iterations < #spindles) && !var.dW }
 ; Must calculate dwell time before spindle speed is changed.
 
 ; Default is to not dwell
-var dT = 0
+var dwellTime = 0
 
 ; D parameter always overrides the dwell time
 if { exists(param.D) }
-    set var.dT = { param.D }
-elif { var.dW }
+    set var.dwellTime = { param.D }
+elif { var.doWait }
     ; Dwell time defaults to the previously timed spindle deceleration time.
-    set var.dT = { global.mosSDS }
+    set var.dwellTime = { global.mosSDS }
 
     ; Now calculate the change in velocity as a percentage
     ; of the maximum spindle speed, and multiply the dwell time
     ; by that percentage with 5% extra leeway.
     ; Ceil this so we always wait a round second, no point waiting
     ; less than 1 anyway.
-    set var.dT = { ceil(var.dT * (abs(spindles[var.sID].current) / spindles[var.sID].max) * 1.05) }
+    set var.dwellTime = { ceil(var.dT * (abs(spindles[var.sID].current) / spindles[var.sID].max) * 1.05) }
 
 ; We run M5 unconditionally for safety purposes. If
 ; the object model is not up to date for whatever
@@ -59,8 +59,20 @@ elif { var.dW }
 ; be stopped.
 M5
 
-; Wait for the spindles to stop, if necessary
-if { var.dT > 0 }
+; No spindles were running, so don't wait
+if { !var.doWait }
+    M99
+
+if { global.mosFeatSpindleFeedback && global.mosSFSID != null }
     if { !global.mosEM }
-        echo { "Waiting " ^ var.dT ^ " seconds for spindle #" ^ var.sID ^ " to stop" }
-    G4 S{var.dT}
+        echo { "Waiting for spindle #" ^ var.sID ^ " to stop based on feedback pin " ^ global.mosSFSID }
+    ; Wait for Spindle Feedback input to change state.
+    ; Wait a maximum of 30 seconds, or abort.
+    M8004 K{global.mosSFSID} D100 W30
+    echo { "Spindle #" ^ var.sID ^ " has stopped based on feedback pin " ^ global.mosSFSID }
+
+; Otherwise wait for spindle to stop manually
+elif { var.dwellTime > 0 }
+    if { !global.mosEM }
+        echo { "Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to stop" }
+    G4 S{var.dwellTime}

--- a/macro/machine/M8003.g
+++ b/macro/machine/M8003.g
@@ -1,0 +1,24 @@
+; M8004.g: LIST CHANGED GPIN PINS SINCE LAST CALL
+;
+; This macro is called when we expect to be able to use
+; a general purpose input to register a change in state.
+; We detect which pins have changed value since the previous
+; call to this macro.
+
+if { !exists(global.mosGPD) }
+    global mosGPD = null
+
+if { !exists(global.mosGPV) }
+    global mosGPV = null
+
+if { global.mosGPD == null || #global.mosGPD != #sensors.gpIn }
+    set global.mosGPD = { vector(#sensors.gpIn, false) }
+    set global.mosGPV = { vector(#sensors.gpIn, null) }
+
+; Loop until a pin is detected or the maximum number of iterations is reached
+while { iterations < #sensors.gpIn }
+    if { global.mosGPV[iterations] != null && global.mosGPV[iterations] != sensors.gpIn[iterations].value }
+        set global.mosGPD[iterations] = true
+        echo { "Pin #" ^ iterations ^ " changed state since last execution" }
+
+    set global.mosGPV[iterations] = sensors.gpIn[iterations].value

--- a/macro/machine/M8004.g
+++ b/macro/machine/M8004.g
@@ -1,0 +1,36 @@
+; M8004.g: WAIT FOR GPIN STATUS CHANGE BY ID
+;
+; This macro is called when we expect to be able to use
+; a general purpose input to register a change in state.
+; We wait for the particular pin to change status.
+
+if { !exists(param.K) || param.K < 0 || param.K >= #sensors.gpIn }
+    abort { "Pin ID not specified or out of range" }
+
+var pinId = { param.K }
+
+; Delay between checking pin status in ms
+var delay = { (exists(param.D)) ? param.D : 100 }
+
+; Maximum time to wait without detecting a status change, in s
+var maxWait = { (exists(param.W)) ? param.W : 30 }
+
+; Calculate number of iterations to reach maxWait
+; at given delay
+var maxIterations = { var.maxWait / (var.delay/1000) }
+
+; Previous pin value
+var previousValue = { null }
+
+; Loop until a pin is detected or the maximum number of iterations is reached
+while { iterations < var.maxIterations }
+    G4 P{ var.delay }
+
+    ; If pin value has changed and we had a previous iteration value, treat this as a detected pin and return.
+    if { sensors.gpIn[var.pinId].value != var.previousValue && var.previousValue != null }
+        M99
+
+    ; If no pin status change detected, save the current value for the next iteration
+    set var.previousValue = { sensors.gpIn[var.pinId].value }
+
+abort { "Pin " ^ var.pinId ^ " status change not detected within " ^ var.maxWait ^ "s! Aborting..."}

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -245,12 +245,12 @@ if { var.wizSpindleAccelSec == null || var.wizSpindleDecelSec == null }
                     set var.wizSpindleChangePinID = { iterations }
                     break
 
-    while { iterations < #var.decelPins }
-        if { var.decelPins[iterations] }
-            M291 P{"GPIO <b>#" ^ iterations ^ "</b> changed state during spindle deceleration. Use this pin for spindle deceleration feedback?"} R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
-            if { input == 0 }
-                set var.wizSpindleStopPinID = { iterations }
-                break
+        while { iterations < #var.decelPins }
+            if { var.decelPins[iterations] }
+                M291 P{"GPIO <b>#" ^ iterations ^ "</b> changed state during spindle deceleration. Use this pin for spindle deceleration feedback?"} R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+                if { input == 0 }
+                    set var.wizSpindleStopPinID = { iterations }
+                    break
 
 ; Write spindle acceleration and deceleration times to the resume file
 echo >>{var.wizTVF} {"set global.mosSAS = " ^ var.wizSpindleAccelSec}

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -68,11 +68,11 @@ if { global.mosTM }
     M291 P{"<b>CAUTION</b>: Follow <b>ALL</b> instructions to the letter, and if you are unsure about any step, please ask for help on our <a target=""_blank"" href=""https://discord.gg/ya4UUj7ax2"">Discord</a>."} R"MillenniumOS: Configuration Wizard" S2 T0
 
 if { var.wizTutorialMode == null }
-    M291 P"Would you like to enable <b>Tutorial Mode</b>?<br/><b>Tutorial Mode</b> describes configuration and probing actions in detail before any action is taken." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+    M291 P"Would you like to enable <b>Tutorial Mode</b>?<br/><b>Tutorial Mode</b> describes configuration and probing actions in detail before any action is taken." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F{ global.mosTM ? 0 : 1 }
     set var.wizTutorialMode = { (input == 0) ? true : false }
 
 if { var.wizExpertMode == null }
-    M291 P"Would you like to enable <b>Expert Mode</b>?<br/><b>Expert Mode</b> disables some confirmation checks before and after operations to reduce operator interaction." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F1
+    M291 P"Would you like to enable <b>Expert Mode</b>?<br/><b>Expert Mode</b> disables some confirmation checks before and after operations to reduce operator interaction." R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F{ global.mosEM ? 0 : 1 }
     set var.wizExpertMode = { (input == 0) ? true : false }
 
 ; Last chance to abort out of the wizard and configure RRF
@@ -117,6 +117,8 @@ if { !var.wizReset && global.mosLdd && !var.wizResumed }
 var wizSpindleID = { (exists(global.mosSID) && global.mosSID != null && !var.wizReset && !var.wizSpindleReset) ? global.mosSID : null }
 var wizSpindleAccelSec = { (exists(global.mosSAS) && global.mosSAS != null && !var.wizReset && !var.wizSpindleReset) ? global.mosSAS : null }
 var wizSpindleDecelSec = { (exists(global.mosSDS) && global.mosSDS != null && !var.wizReset && !var.wizSpindleReset) ? global.mosSDS : null }
+var wizSpindleChangePinID = { (exists(global.mosSFCID) && global.mosSFCID != null && !var.wizReset && !var.wizSpindleReset) ? global.mosSFCID : null }
+var wizSpindleStopPinID = { (exists(global.mosSFSID) && global.mosSFSID != null && !var.wizReset && !var.wizSpindleReset) ? global.mosSFSID : null }
 var wizDatumToolRadius = { (exists(global.mosDTR) && global.mosDTR != null && !var.wizReset && !var.wizDatumToolReset) ? global.mosDTR : null }
 var wizToolSetterID = { (exists(global.mosTSID) && global.mosTSID != null && !var.wizReset && !var.wizToolSetterReset) ? global.mosTSID : null }
 var wizToolSetterPos = { (exists(global.mosTSP) && global.mosTSP != null && !var.wizReset && !var.wizToolSetterReset) ? global.mosTSP : null }
@@ -164,26 +166,32 @@ if { var.wizSpindleID == null }
 echo >>{var.wizTVF} { "set global.mosSID = " ^ var.wizSpindleID }
 
 ; Spindle Feedback Feature Enable / Disable
-; if { var.wizFeatureSpindleFeedback == null }
-;     M291 P"Would you like to enable the <b>Spindle Feedback</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F1
-;     set var.wizFeatureSpindleFeedback = { (input == 0) ? true : false }
-;
-;     ; Do not display this if the setting was not changed
-;     if { var.wizFeatureSpindleFeedback }
-;         M291 P"Spindle Feedback feature not yet implemented, falling back to manual timing of spindle acceleration and deceleration." R"MillenniumOS: Configuration Wizard" S2 T0
-;         set var.wizFeatureSpindleFeedback = false
-set var.wizFeatureSpindleFeedback = false
+if { var.wizFeatureSpindleFeedback == null }
+    M291 P"Would you like to enable the <b>Spindle Feedback</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F{ global.mosFeatSpindleFeedback ? 0 : 1}
+    set var.wizFeatureSpindleFeedback = { (input == 0) ? true : false }
+
+    ; Do not display this if the setting was not changed
+    if { var.wizFeatureSpindleFeedback && var.wizTutorialMode }
+        M291 P"The Spindle Feedback feature can be used to detect when a spindle has reached a target speed, has stopped, or both. How you use this will depend on your VFD configuration." R"MillenniumOS: Configuration Wizard" S2 T0
+        M291 P"We will start the spindle so we can measure the time it takes to accelerate and decelerate - these values will be used if you disable the Spindle Feedback feature later." R"MillenniumOS: Configuration Wizard" S2 T0
+        M291 P"While doing this, we will monitor the state of any configured general purpose inputs and ask you to confirm if these should be used for spindle feedback." R"MillenniumOS: Configuration Wizard" S2 T0
 
 ; Write spindle feedback feature to the resume file
 echo >>{var.wizTVF} {"set global.mosFeatSpindleFeedback = " ^ var.wizFeatureSpindleFeedback}
 
-; TODO: Do not display this when spindle speed feedback enabled and configured
 if { var.wizSpindleAccelSec == null || var.wizSpindleDecelSec == null }
-    M291 P"We need to start the spindle and accelerate to its maximum RPM, to measure how long it takes.<br/><b>CAUTION</b>: Remove any tool and make sure your spindle nut is tightened before proceeding!" R"MillenniumOS: Configuration Wizard" S3 T0
+    M291 P"We need to start the spindle and accelerate to its maximum RPM.<br/><b>CAUTION</b>: Remove any tool and make sure your spindle nut is tightened before proceeding!" R"MillenniumOS: Configuration Wizard" S3 T0
     if { result != 0 }
         abort { "MillenniumOS: Operator aborted configuration wizard!" }
 
     M291 P"When ready, click <b>OK</b> to start the spindle.<br />When it is no longer accelerating, click <b>OK</b> on the next screen." R"MillenniumOS: Configuration Wizard" S3 T0
+
+    var accelPins = { null }
+    var decelPins = { null }
+
+    ; If spindle feedback is enabled, use M8003 to check which pins change state during acceleration.
+    if { var.wizFeatureSpindleFeedback }
+        M8003
 
     ; Store start time
     set var.wizSpindleAccelSec = { state.time }
@@ -197,6 +205,10 @@ if { var.wizSpindleAccelSec == null || var.wizSpindleDecelSec == null }
     ; Calculate the time it took to accelerate
     set var.wizSpindleAccelSec = { state.time - var.wizSpindleAccelSec }
 
+    if { var.wizFeatureSpindleFeedback }
+        M8003
+        set var.accelPins = { global.mosGPD }
+
     ; Prompt to do the same for deceleration
     M291 P"Now we need to measure deceleration. When ready, click <b>OK</b> to stop the spindle.<br />When it has stopped, click <b>OK</b> on the next screen." R"MillenniumOS: Configuration Wizard" S2 T0
 
@@ -206,11 +218,18 @@ if { var.wizSpindleAccelSec == null || var.wizSpindleDecelSec == null }
     ; Stop spindle
     M5 P{var.wizSpindleID}
 
+    if { var.wizFeatureSpindleFeedback }
+        M8003
+
     ; Prompt user to click OK when the spindle has stopped decelerating
     M291 P"Click <b>OK</b> when the spindle has stopped!" R"MillenniumOS: Configuration Wizard" S2 T0
 
-    ; Calculate the time it took to accelerate
+    ; Calculate the time it took to decelerate
     set var.wizSpindleDecelSec = { state.time - var.wizSpindleDecelSec }
+
+    if { var.wizFeatureSpindleFeedback }
+        M8003
+        set var.decelPins = { global.mosGPD }
 
     ; Just in case the user forgets to click, or some other issue occurs (clock rollover? lol)
     ; throw an error.
@@ -218,9 +237,28 @@ if { var.wizSpindleAccelSec == null || var.wizSpindleDecelSec == null }
     if { var.wizSpindleAccelSec > 120 || var.wizSpindleDecelSec > 120 }
         abort { "MillenniumOS: Calculated spindle acceleration or deceleration time is too long!" }
 
+    if { var.wizFeatureSpindleFeedback }
+        while { iterations < #var.accelPins }
+            if { var.accelPins[iterations] }
+                M291 P{"GPIO <b>#" ^ iterations ^ "</b> changed state during spindle acceleration. Use this pin for spindle acceleration feedback?"} R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+                if { input == 0 }
+                    set var.wizSpindleChangePinID = { iterations }
+                    break
+
+    while { iterations < #var.decelPins }
+        if { var.decelPins[iterations] }
+            M291 P{"GPIO <b>#" ^ iterations ^ "</b> changed state during spindle deceleration. Use this pin for spindle deceleration feedback?"} R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+            if { input == 0 }
+                set var.wizSpindleStopPinID = { iterations }
+                break
+
 ; Write spindle acceleration and deceleration times to the resume file
 echo >>{var.wizTVF} {"set global.mosSAS = " ^ var.wizSpindleAccelSec}
 echo >>{var.wizTVF} {"set global.mosSDS = " ^ var.wizSpindleDecelSec}
+
+; Write spindle feedback pins to the resume file
+echo >>{var.wizTVF} {"set global.mosSFCID = " ^ var.wizSpindleChangePinID}
+echo >>{var.wizTVF} {"set global.mosSFSID = " ^ var.wizSpindleStopPinID}
 
 if { var.wizDatumToolRadius == null }
     if { var.wizTutorialMode }
@@ -237,12 +275,12 @@ echo >>{var.wizTVF} {"set global.mosDTR = " ^ var.wizDatumToolRadius }
 
 ; Toolsetter Feature Enable / Disable
 if { var.wizFeatureToolSetter == null }
-    M291 P"Would you like to enable the <b>Toolsetter</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F0
+    M291 P"Would you like to enable the <b>Toolsetter</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F{ global.mosFeatToolSetter ? 0 : 1 }
     set var.wizFeatureToolSetter = { (input == 0) ? true : false }
 
 ; Touch Probe Feature Enable / Disable
 if { var.wizFeatureTouchProbe == null }
-    M291 P"Would you like to enable the <b>Touch Probe</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F1
+    M291 P"Would you like to enable the <b>Touch Probe</b> feature?" R"MillenniumOS: Configuration Wizard" S4 T0 K{"Yes","No"} F{ global.mosFeatTouchProbe ? 0 : 1 }
     set var.wizFeatureTouchProbe = { (input == 0) ? true : false }
 
 ; Write feature settings to the resume file
@@ -589,6 +627,10 @@ echo >>{var.wizUVF} "; Spindle Acceleration Sec"
 echo >>{var.wizUVF} {"set global.mosSAS = " ^ var.wizSpindleAccelSec}
 echo >>{var.wizUVF} "; Spindle Deceleration Sec"
 echo >>{var.wizUVF} {"set global.mosSDS = " ^ var.wizSpindleDecelSec}
+
+echo >>{var.wizUVF} "; Spindle Feedback Pins"
+echo >>{var.wizUVF} {"set global.mosSFCID = " ^ var.wizSpindleChangePinID}
+echo >>{var.wizUVF} {"set global.mosSFSID = " ^ var.wizSpindleStopPinID}
 echo >>{var.wizUVF} ""
 
 echo >>{var.wizUVF} "; Datum Tool Radius"

--- a/macro/public/3. Config/Settings/Toggle Spindle Feedback.g
+++ b/macro/public/3. Config/Settings/Toggle Spindle Feedback.g
@@ -1,0 +1,14 @@
+; Toggle Spindle Feedback.g
+
+if { global.mosFeatSpindleFeedback }
+    M291 R"MillenniumOS: Toggle Spindle Feedback" P"Disable Spindle Feedback? We will fall back to manual delays." S3
+    if { result == -1 }
+        M99
+
+if { global.mosSFCID == null && global.mosSFSID == null }
+    M291 R"MillenniumOS: Toggle Spindle Feedback" P"Spindle Feedback has not been configured. Please reconfigure the Spindle settings using the Configuration Wizard first." S2
+    M99
+
+set global.mosFeatSpindleFeedback = {!global.mosFeatSpindleFeedback}
+
+echo {"MillenniumOS: Spindle Feedback " ^ (global.mosFeatSpindleFeedback ? "Enabled" : "Disabled")}

--- a/macro/public/3. Config/Settings/Toggle Toolsetter.g
+++ b/macro/public/3. Config/Settings/Toggle Toolsetter.g
@@ -1,7 +1,7 @@
 ; Toggle Toolsetter.g
 
 if { global.mosFeatToolSetter }
-    M291 R"MillenniumOS: Toggle Toolsetter" P"Disable Toolsetter? You will have to compensate for tool length manually." S3
+    M291 R"MillenniumOS: Toggle Toolsetter" P"Disable Toolsetter? You will be asked to reset the origin in Z after each tool change!" S3
     if { result == -1 }
         M99
 

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -61,14 +61,13 @@ if { (global.mosFeatToolSetter || global.mosFeatTouchProbe) && global.mosPMBO ==
     set global.mosErr = { "<b>global.mosPMBO</b> is not set." }
     M99
 
-if { !global.mosFeatSpindleFeedback }
-    if { !exists(global.mosSAS) || global.mosSAS == null }
-        set global.mosErr = { "<b>global.mosSAS</b> is not set." }
-        M99
+if { !exists(global.mosSAS) || global.mosSAS == null }
+    set global.mosErr = { "<b>global.mosSAS</b> is not set." }
+    M99
 
-    if { !exists(global.mosSDS) || global.mosSDS == null }
-        set global.mosErr = { "<b>global.mosSDS</b> is not set." }
-        M99
+if { !exists(global.mosSDS) || global.mosSDS == null }
+    set global.mosErr = { "<b>global.mosSDS</b> is not set." }
+    M99
 
 ; Allow MOS macros to run.
 set global.mosLdd = true

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -128,45 +128,46 @@ global mosWPSfcPos = null
 global mosWPSfcAxis = null
 
 ; Canned Cycle settings
-global mosCCD = null ; Canned Cycle Drilling
+global mosCCD = null ; Canned Cycle Drilling status
 
 ; Daemon settings
 ; Required for regular task updates (e.g. VSSC)
-global mosDAE = true
+global mosDAE = true  ; Daemon Enable
 
-global mosDAEUR = 500  ; Re-trigger background tasks every 500ms
-                                  ; don't reduce this below 500!
+global mosDAEUR = 500 ; Daemon Update Rate (ms) - do not reduce below 500
 
 ; Do not change these variables directly, use the VSSC control M-codes instead
-global mosVSEnabled = false
-global mosVSOE = true
-global mosVSP = 0
-global mosVSV = 0.0
-global mosVSPT = 0
-global mosVSPS = 0.0
+global mosVSEnabled = false ; VSSC enabled
+global mosVSOE = true       ; VSSC Override enabled
+global mosVSP = 0           ; VSSC Period
+global mosVSV = 0.0         ; VSSC Variance
+global mosVSPT = 0          ; VSSC Previous Adjustment Time
+global mosVSPS = 0.0        ; VSSC Previous Adjustment Speed
 
 ; Spindle configuration
-global mosSID = null
-global mosSAS = null
-global mosSDS = null
+global mosSID = null  ; Spindle ID
+global mosSFCID = null ; Spindle Feedback Change ID
+global mosSFSID = null ; Spindle Feedback Stop ID
+global mosSAS = null  ; Spindle Acceleration (s) - feedback disabled
+global mosSDS = null  ; Spindle Deceleration (s) - feedback disabled
 
 ; Toolsetter configuration
-global mosTSID = null
-global mosTSP = null
-global mosTSR = null
-global mosTSAP = null
+global mosTSID = null ; Toolsetter ID
+global mosTSP = null  ; Toolsetter Position
+global mosTSR = null  ; Toolsetter Radius
+global mosTSAP = null ; Toolsetter Activation Point
 
 ; Touch probe configuration
-global mosTPID = null
-global mosTPR = null
-global mosTPD = null
-global mosTPRP = null
+global mosTPID = null ; Touch Probe ID
+global mosTPR = null  ; Touch Probe Radius
+global mosTPD = null  ; Touch Probe Deflection
+global mosTPRP = null ; Touch Probe Reference Point
 
 ; Datum tool configuration
-global mosDTR = null
+global mosDTR = null ; Datum Tool Radius
 
 ; Protected move configuration
-global mosPMBO = null
+global mosPMBO = null ; Protected Move Back Off
 
 ; Manual probing feed rates - travel, rough, fine
 global mosMPS = { 1200, 300, 60 }
@@ -198,6 +199,11 @@ global mosDPID = null
 ; Used during runtime to indicate a
 ; specific probe ID has been detected.
 global mosPD = null
+
+; Used during runtime to detect GPIO
+; pins which have changed state.
+global mosGPV = null
+global mosGPD = null
 
 ; Tracks whether description messages have been
 ; displayed during this session. The first 2 indexes


### PR DESCRIPTION
Spindle feedback allows a relay in your VFD to control a GPIO input to RRF that can indicate that the spindle is up to speed or not.

Rather than using manual delays which are timed during the configuration wizard, you can now enable spindle feedback and you will be prompted after starting and stopping the spindle in the wizard whether you want to configure any GPIO inputs that changed state as a spindle feedback input.

It is possible to use the same pin for both acceleration or changing speed, and stopping, or you can use 2 different pins. Which to use will depend on your VFD configuration and number of outputs.
