### PR TITLE
Add Rotation Compensation and per-WCS probing changes to Fusion360 Post-Processor

### DIFF
--- a/macro/machine/M5011.g
+++ b/macro/machine/M5011.g
@@ -21,7 +21,8 @@ if { global.mosWPDeg[var.workOffset] != global.mosDfltWPDeg }
             echo { "MillenniumOS: Rotation compensation not applied."}
             M99
 
-    ; Rotate the workpiece around the origin of the current WCS
+    ; Rotate the workpiece around the center.
+    ; Find the center by subtracting the
     G68 X0 Y0 R{global.mosWPDeg[var.workOffset]}
 
-    echo { "MillenniumOS: Rotation compensation of " ^ -global.mosWPDeg[var.workOffset] ^ " degrees applied." }
+    echo { "MillenniumOS: Rotation compensation of " ^ -global.mosWPDeg[var.workOffset] ^ " degrees applied around origin" }

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -289,4 +289,4 @@ if { !exists(param.R) || param.R != 0 }
 
 ; Set WCS origin to the probed corner
 echo { "MillenniumOS: Setting WCS " ^ var.wcsNumber ^ " X,Y origin to " ^ global.mosCnr[param.N] ^ " corner." }
-G10 L2 P{param.W} X{var.cX} Y{var.cY}
+G10 L2 P{var.wcsNumber} X{var.cX} Y{var.cY}

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -778,7 +778,10 @@ class MillenniumOSPostProcessor(PostProcessor):
 
 
     def onfixture(self, _):
-        pass
+        self._forceTool()
+        self._forceFeed()
+        self._forceSpindle()
+        self.spindle_started = False
 
 
     def onoperation(self, op):
@@ -942,7 +945,7 @@ class MillenniumOSPostProcessor(PostProcessor):
             self.brk()
             self.comment("Begin postamble")
             self.brk()
-            self.comment("Park at user-defined location")
+            self.comment("Park")
             self.G(GCODES.PARK)
             self.brk()
 

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -71,7 +71,7 @@ allowSpiralMoves      = false;             // Linearize spirals (circular moves 
 allowedCircularPlanes = undefined;         // Allow arcs on all planes
 
 // Base WCS number, offset is added to this
-var wcsBase = 54;
+var wcsBase = 53;
 
 // Define WCS probing modes
 var wcsProbeMode = {
@@ -363,7 +363,7 @@ var mCodes = createModalGroup(
     [0, 2],                           // Program codes
     [M.ADD_TOOL],                     // Tool data codes
     [M.VERSION_CHECK],                // Version check
-    [M.VSSC_ENABLE, M.VSSC_DISABLE]   // VSSC codes
+    [M.VSSC_ENABLE, M.VSSC_DISABLE],  // VSSC codes
     [M.ENABLE_ROTATION_COMPENSATION]  // Rotation compensation
   ],
   mFmt);
@@ -638,7 +638,7 @@ function onSection() {
   var wcsCode = wcsBase + curWorkOffset;
 
   // If WCS is changing,
-  if (wcsChanging) {
+  if(wcsChanging) {
     writeComment("Park ready for WCS change");
     writeBlock(gCodesF.format(G.PARK));
     writeln("");
@@ -655,6 +655,7 @@ function onSection() {
 
   writeComment("Enable rotation compensation if necessary");
   writeBlock(mCodes.format(M.ENABLE_ROTATION_COMPENSATION));
+  writeln("");
 
   // If tool requires changing or wcs was probed
   // We must force a tool change if probe was required
@@ -1102,12 +1103,6 @@ function onClose() {
   writeComment("Park");
   writeBlock(gCodesF.format(G.PARK));
   writeln("");
-
-  if(getProperty("vsscEnabled")) {
-    writeComment("Disable Variable Spindle Speed Control");
-    writeBlock(mCodes.format(M.VSSC_DISABLE));
-    writeln("");
-  }
 
   writeComment("Double-check spindle is stopped!");
   // Use M98 to call the M3.9 macro, as there is currently an RRF bug that


### PR DESCRIPTION
The Fusion360 post-processor now outputs the gcode commands required for multiple-WCS probing, as well as applying rotation compensation to the active WCS.

**WARNING**: This changes the way the `work offset` setting in Fusion360 `Setup` works - `0` and `1` now refer to `G54`, with `G55` being 2. This matches how industry-standard post-processors work.