### PR TITLE
Switch back to calling M3.9 and M5.9 directly

### DIFF
--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -766,10 +766,6 @@ class MillenniumOSPostProcessor(PostProcessor):
 
         code += self._SPINDLE_WAIT_SUFFIX
 
-        macro = "M{}.g".format(code)
-        code = MCODES.CALL_MACRO
-        params['P'] = macro
-
         cmd, _ = self._M(code, **params)
         if not cmd:
             return None

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -233,7 +233,7 @@ var radiusFmt = axesFmt;
 var feedFmt   = createFormat({decimals:(unit == MM ? 1 : 2), type: FORMAT_REAL, minDigitsRight: 1 });
 
 // Used for integer output - RPM, seconds, tool properties etc
-var intFmt = createFormat({ type: FORMAT_INTEGER });
+var intFmt = createFormat({ type: FORMAT_INTEGER, decimals: 0 });
 
 // Force output of G, M and T commands when executed
 var gCmd = createOutputVariable({ control: CONTROL_FORCE }, gFmt );
@@ -690,19 +690,7 @@ function onSection() {
     // because modal groups do not correctly handle
     // decimals.
 
-    // Use M98 to call the M3.9 macro, as there is currently an RRF bug that
-    // prevents delays from running in macros called directly.
-    // More info here: https://forum.duet3d.com/topic/35300/odd-g4-behaviour-from-macro-called-from-sd-file/13?_=1711622479937
-    // NOTE: The P parameter conflicts between M98 and M3, so
-    // using this approach we _cannot_ target a specific spindle.
-    // We don't do that anyway, because we select a tool before
-    // setting the spindle speed, but it's worth noting - if there
-    // is no tool selected, then this command will return an error.
-    writeBlock(mFmt.format(M.CALL_MACRO), 'P"M{code}.g"'.supplant({code: M.SPINDLE_ON_CW}), s);
-
-    // Uncomment this when RRF fixes delays not running in macros called
-    // directly.
-    //writeBlock(mFmt.format(M.SPINDLE_ON_CW), s);
+    writeBlock(mFmt.format(M.SPINDLE_ON_CW), s);
     writeln("");
   }
 
@@ -1105,19 +1093,7 @@ function onClose() {
   writeln("");
 
   writeComment("Double-check spindle is stopped!");
-  // Use M98 to call the M3.9 macro, as there is currently an RRF bug that
-  // prevents delays from running in macros called directly.
-  // More info here: https://forum.duet3d.com/topic/35300/odd-g4-behaviour-from-macro-called-from-sd-file/13?_=1711622479937
-  // NOTE: The P parameter conflicts between M98 and M3, so
-  // using this approach we _cannot_ target a specific spindle.
-  // We don't do that anyway, because we select a tool before
-  // setting the spindle speed, but it's worth noting - if there
-  // is no tool selected, then this command will return an error.
-  writeBlock(mFmt.format(M.CALL_MACRO), 'P"M{code}.g"'.supplant({code: M.SPINDLE_OFF}));
-
-  // Uncomment this when RRF fixes delays not running in macros called
-  // directly.
-  // writeBlock(mFmt.format(M.SPINDLE_OFF));
+  writeBlock(mFmt.format(M.SPINDLE_OFF));
   writeln("");
 }
 


### PR DESCRIPTION
It appears the bug with dwells in RRF 3.5.0 has been fixed in 3.5.2 so we can now switch back to the previous way of calling the spindle control commands.