### PR TITLE
Revert spindle control to calling `M3.9` and `M5.9` directly

### DIFF
--- a/macro/machine/M3.9.g
+++ b/macro/machine/M3.9.g
@@ -31,6 +31,9 @@ if { exists(param.S) }
 if { exists(param.D) && param.D < 0 }
     abort { "Dwell time must be a positive value!" }
 
+; Wait for all movement to stop before continuing.
+M400
+
 ; True if spindle is stopping
 var sStopping = { spindles[var.sID].current > 0 && param.S == 0 }
 

--- a/macro/machine/M5.9.g
+++ b/macro/machine/M5.9.g
@@ -17,6 +17,9 @@ if { !inputs[state.thisInput].active }
 if { exists(param.D) && param.D < 0 }
     abort { "Dwell time must be a positive value!" }
 
+; Wait for all movement to stop before continuing.
+M400
+
 ; Spindles only need to be stopped if they're actually running.
 ; The base M5 code will stop the spindle for the current tool, or
 ; all spindles if no tool is selected. To avoid having to wait the

--- a/macro/movement/G27.g
+++ b/macro/movement/G27.g
@@ -20,10 +20,13 @@ G94
 G53 G0 Z{move.axes[2].max}
 
 ; Stop spindle and wait
-M98 P"M5.9.g"
+M5.9
 
 ; If park is called with Z parameter, then the table itself will not be
 ; moved.
 if { !exists(param.Z) }
     ; Move table to center of X, and front of Y
     G53 G0 X{(move.axes[0].max - move.axes[0].min)/2} Y{move.axes[1].max}
+
+; Wait for all movement to stop before continuing.
+M400

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -766,10 +766,6 @@ class MillenniumOSPostProcessor(PostProcessor):
 
         code += self._SPINDLE_WAIT_SUFFIX
 
-        macro = "M{}.g".format(code)
-        code = MCODES.CALL_MACRO
-        params['P'] = macro
-
         cmd, _ = self._M(code, **params)
         if not cmd:
             return None

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -233,7 +233,7 @@ var radiusFmt = axesFmt;
 var feedFmt   = createFormat({decimals:(unit == MM ? 1 : 2), type: FORMAT_REAL, minDigitsRight: 1 });
 
 // Used for integer output - RPM, seconds, tool properties etc
-var intFmt = createFormat({ type: FORMAT_INTEGER });
+var intFmt = createFormat({ type: FORMAT_INTEGER, decimals: 0 });
 
 // Force output of G, M and T commands when executed
 var gCmd = createOutputVariable({ control: CONTROL_FORCE }, gFmt );
@@ -690,19 +690,7 @@ function onSection() {
     // because modal groups do not correctly handle
     // decimals.
 
-    // Use M98 to call the M3.9 macro, as there is currently an RRF bug that
-    // prevents delays from running in macros called directly.
-    // More info here: https://forum.duet3d.com/topic/35300/odd-g4-behaviour-from-macro-called-from-sd-file/13?_=1711622479937
-    // NOTE: The P parameter conflicts between M98 and M3, so
-    // using this approach we _cannot_ target a specific spindle.
-    // We don't do that anyway, because we select a tool before
-    // setting the spindle speed, but it's worth noting - if there
-    // is no tool selected, then this command will return an error.
-    writeBlock(mFmt.format(M.CALL_MACRO), 'P"M{code}.g"'.supplant({code: M.SPINDLE_ON_CW}), s);
-
-    // Uncomment this when RRF fixes delays not running in macros called
-    // directly.
-    //writeBlock(mFmt.format(M.SPINDLE_ON_CW), s);
+    writeBlock(mFmt.format(M.SPINDLE_ON_CW), s);
     writeln("");
   }
 
@@ -1105,19 +1093,7 @@ function onClose() {
   writeln("");
 
   writeComment("Double-check spindle is stopped!");
-  // Use M98 to call the M3.9 macro, as there is currently an RRF bug that
-  // prevents delays from running in macros called directly.
-  // More info here: https://forum.duet3d.com/topic/35300/odd-g4-behaviour-from-macro-called-from-sd-file/13?_=1711622479937
-  // NOTE: The P parameter conflicts between M98 and M3, so
-  // using this approach we _cannot_ target a specific spindle.
-  // We don't do that anyway, because we select a tool before
-  // setting the spindle speed, but it's worth noting - if there
-  // is no tool selected, then this command will return an error.
-  writeBlock(mFmt.format(M.CALL_MACRO), 'P"M{code}.g"'.supplant({code: M.SPINDLE_OFF}));
-
-  // Uncomment this when RRF fixes delays not running in macros called
-  // directly.
-  // writeBlock(mFmt.format(M.SPINDLE_OFF));
+  writeBlock(mFmt.format(M.SPINDLE_OFF));
   writeln("");
 }
 


### PR DESCRIPTION
Also modify these commands so they wait appropriately for movement to stop before adjusting spindle speed.

Also wait for movement to stop when parking and stopping the spindle.