### PR TITLE
Do not allow gcode output in inches

### DIFF
--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -518,8 +518,7 @@ function onOpen() {
       writeBlock(gCodes.format(21));
       break;
     case IN:
-      writeBlock(gCodes.format(20));
-      break;
+      error("MillenniumOS does not support gcode output in inches. Please switch your post-processor output to millimeters.");
   }
 
   // All feeds in mm/min


### PR DESCRIPTION
Internally, MillenniumOS uses metric for all calculations. Inches actually work fine in RRF after switching using `G21`, but If you select Inches in the Fusion post settings then all the tool details are outputted as inches before the `G21` command.

The reality is, there's no real need to output in inches (unless you like checking the gcode by hand and not having to convert to freedom units).

You can work in inches in CAD / CAM and output the file in millimeters and the machine will run the file correctly.

I'm disallowing output in inches here to avoid undefined behaviour when inches is selected in the post-processor. If you have a problem with that please create an issue on this repository with a good reason and I'll see how much work it'll be to make the post-processor support it properly.
