### PR TITLE
bug: fix Vector compared to String in MOS wizard

### DIFF
--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -488,7 +488,7 @@ if { var.wizFeatureToolSetter }
         ; Distance to move towards target is the lower of (min Z - current Z) or 20mm.
         G6510.1 R0 W{null} H4 I{min(abs(move.axes[2].min - move.axes[2].machinePosition), 20)} O0 J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}
 
-        if { global.mosWPSfcPos == null || global.mosWPSfcAxis != "Z" }
+        if { global.mosWPSfcPos == null || global.mosWPSfcAxis[move.workplaceNumber] != "Z" }
             abort { "MillenniumOS: Failed to probe the reference surface!" }
 
         ; Store the reference surface position in Z


### PR DESCRIPTION
As reported by Vinnnocc in the MillenniumOS Discord channel 
![Screenshot_2024-06-23_at_2 25 37_PM](https://github.com/MillenniumMachines/MillenniumOS/assets/18535830/66a41cc1-ea3b-4adc-84be-7f2ba9fed0e7)
