### PR TITLE
Replace version number in all system macros

### DIFF
--- a/dist/release.sh
+++ b/dist/release.sh
@@ -27,7 +27,7 @@ find ${TMP_DIR}
 cd "${TMP_DIR}"
 mv sys/daemon.g sys/daemon.install
 echo "Replacing %%MOS_VERSION%% with ${COMMIT_ID}..."
-sed -si -e "s/%%MOS_VERSION%%/${COMMIT_ID}/g" {sys/mos.g,posts/*}
+sed -si -e "s/%%MOS_VERSION%%/${COMMIT_ID}/g" {sys/*.g,posts/*}
 cp -v posts/* "${WD}/dist"
 zip -x 'README.md' -x 'posts/' -x 'posts/**' -r "${ZIP_PATH}" *
 cd "${WD}"


### PR DESCRIPTION
This allows version comparison using `M4005`.