### PR TITLE
Fix logic issue when passing W param to M7601

### DIFF
--- a/macro/machine/M7601.g
+++ b/macro/machine/M7601.g
@@ -8,7 +8,7 @@
 ; expert mode is on.
 
 
-if { !exists(param.W) || param.W < 0 || param.W >= limits.workplaces }
+if { exists(param.W) && (param.W < 0 || param.W >= limits.workplaces) }
     abort { "Work Offset must be between 0 and " ^ limits.workplaces-1 ^ "!" }
 
 var workOffset = { (exists(param.W) && param.W != null) ? param.W : move.workplaceNumber }


### PR DESCRIPTION
This doesn't fix an active bug as we don't pass the `W` parameter to `M7601` anywhere, but it would potentially cause an error if the operator were to call `M7601` directly with a `W` parameter.