### PR TITLE
Fix missing `var.workOffset` index on Outside Corner probe

### DIFF
--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -276,7 +276,7 @@ if { var.pMO == 0 }
 
     ; Calculate the center of the workpiece based on the corner position,
     ; the width and height of the workpiece and the rotation.
-    set global.mosWPCtrPos = { var.cX + ((var.fX/2) * cos(radians(var.aR)) - (var.fY/2) * sin(radians(var.aR))), var.cY + ((var.fX/2) * sin(radians(var.aR)) + (var.fY/2) * cos(radians(var.aR))) }
+    set global.mosWPCtrPos[var.workOffset] = { var.cX + ((var.fX/2) * cos(radians(var.aR)) - (var.fY/2) * sin(radians(var.aR))), var.cY + ((var.fX/2) * sin(radians(var.aR)) + (var.fY/2) * cos(radians(var.aR))) }
 
     ; If running in full mode, operator provided approximate width and
     ; height values of the workpiece. Assign these to the global


### PR DESCRIPTION
`global.mosWPCtrPos` was not being indexed properly by work offset in `G6508.1` (Outside Corner probe). This would throw an error and break the structure of the `global.mosWPCtrPos` variable, but the WCS origin would still be set correctly as this does not rely on the global variables.

This PR fixes the error and allows the centre position to be available and valid in the stored WCS details.