### PR TITLE
Make sure corner and surface names can be overridden

### DIFF
--- a/macro/machine/M7601.g
+++ b/macro/machine/M7601.g
@@ -28,7 +28,7 @@ if { !global.mosEM }
 
     if { global.mosWPCnrNum[var.workOffset] != null }
         echo {"WCS " ^ var.wcsNumber ^ " - Probed Corner Number=" ^ global.mosWPCnrNum[var.workOffset] }
-        echo {"WCS " ^ var.wcsNumber ^ " - Probed Corner Name=" ^ global.mosCnr[global.mosWPCnrNum[var.workOffset]] }
+        echo {"WCS " ^ var.wcsNumber ^ " - Probed Corner Name=" ^ global.mosCornerNames[global.mosWPCnrNum[var.workOffset]] }
 
     if { global.mosWPCnrPos[var.workOffset][0] != null && global.mosWPCnrPos[var.workOffset][1] != null}
         echo {"WCS " ^ var.wcsNumber ^ " - Probed Corner Position X=" ^ global.mosWPCnrPos[var.workOffset][0] ^ " Y=" ^ global.mosWPCnrPos[var.workOffset][1] }

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -305,5 +305,5 @@ if { !exists(param.R) || param.R != 0 }
     M7601 W{var.workOffset}
 
 ; Set WCS origin to the probed corner
-echo { "MillenniumOS: Setting WCS " ^ var.wcsNumber ^ " X,Y origin to " ^ global.mosCnr[param.N] ^ " corner." }
+echo { "MillenniumOS: Setting WCS " ^ var.wcsNumber ^ " X,Y origin to " ^ global.mosCornerNames[param.N] ^ " corner." }
 G10 L2 P{var.wcsNumber} X{var.cX} Y{var.cY}

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -104,7 +104,7 @@ M291 P"Please jog the probe <b>OVER</b> the corner and press <b>OK</b>.<br/><b>C
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
 
-M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Outside Corner" T0 S4 K{global.mosCnr}
+M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Outside Corner" T0 S4 K{global.mosCornerNames}
 if { result != 0 }
     abort { "Outside corner probe aborted!" }
 
@@ -121,7 +121,7 @@ if { var.probingDepth < 0 }
 
 ; Run the block probe cycle
 if { global.mosTM }
-    var cN = { global.mosCnr[var.corner] }
+    var cN = { global.mosCornerNames[var.corner] }
     M291 P{"We will now move outside the <b>" ^ var.cN ^ "</b> corner, down by " ^ var.probingDepth ^ "mm and probe each surface forming the corner." } R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Outside corner probe aborted!" }

--- a/macro/movement/G6510.g
+++ b/macro/movement/G6510.g
@@ -12,16 +12,8 @@
 if { !inputs[state.thisInput].active }
     M99
 
-; Friendly names to indicate the location of a surface to be probed, relative to the tool.
-; Left means 'surface is to the left of the tool', i.e. we will move the table towards the
-; _right_ to probe it.
-; If your machine is configured with the axes in a different orientation, you can override
-; these names in mos-user-vars.g but there is no way to override the "Below" option (which)
-; is a Z axis, and always probes towards Z minimum. On the Milo, Z Max is 0 and Z min is 60 or 120.
-var surfaceLocationNames = {"Left","Right","Front","Back","Top"}
-
 ; Index of the zProbe entry as this requires different inputs.
-var zProbeI = { #var.surfaceLocationNames - 1 }
+var zProbeI = { #global.mosSurfaceNames - 1 }
 
 ; Display description of surface probe if not displayed this session
 if { global.mosTM && !global.mosDD[4] }
@@ -57,7 +49,7 @@ if { result != 0 }
     abort { "Surface probe aborted!" }
 
 ; Prompt the operator for the location of the surface
-M291 P"Please select the surface to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Surface" T0 S4 F{var.zProbeI} K{var.surfaceLocationNames}
+M291 P"Please select the surface to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Surface" T0 S4 F{var.zProbeI} K{global.mosSurfaceNames}
 var probeAxis = { input }
 
 ; For Z probes, our depth is 0 but our distance is the probing depth
@@ -87,11 +79,11 @@ if { var.probeDist < 0 }
 
 if { global.mosTM }
     if { !var.isZProbe }
-        M291 P{"Probe will now move down <b>" ^ var.probeDepth ^ "</b> mm and probe towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+        M291 P{"Probe will now move down <b>" ^ var.probeDepth ^ "</b> mm and probe towards the <b>" ^ global.mosSurfaceNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
         if { input != 0 }
             abort { "Single Surface probe aborted!" }
     else
-        M291 P{"Probe will now move towards the <b>" ^ var.surfaceLocationNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
+        M291 P{"Probe will now move towards the <b>" ^ global.mosSurfaceNames[var.probeAxis] ^ "</b> surface." } R"MillenniumOS: Probe Surface" T0 S4 K{"Continue", "Cancel"} F0
         if { input != 0 }
             abort { "Single Surface probe aborted!" }
 

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -31,7 +31,7 @@ if { !exists(param.P) }
 if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) }
     abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
 
-if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCnr) }
+if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCornerNames) }
     abort { "Must provide a valid corner index using the N parameter!" }
 
 ; Default workOffset to the current workplace number if not specified

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -106,7 +106,7 @@ M291 P"Please jog the probe <b>OVER</b> the corner and press <b>OK</b>.<br/><b>C
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
-M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Vise Corner" T0 S4 K{global.mosCnr}
+M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names are relative to an operator standing at the front of the machine." R"MillenniumOS: Probe Vise Corner" T0 S4 K{global.mosCornerNames}
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
@@ -123,7 +123,7 @@ if { var.probeDepth < 0 }
 
 ; Run the block probe cycle
 if { global.mosTM }
-    var cN = { global.mosCnr[var.corner] }
+    var cN = { global.mosCornerNames[var.corner] }
     M291 P{"We will now probe the top surface, then move outside the <b>" ^ var.cN ^ "</b> corner, down " ^ var.probeDepth ^ "mm, and probe each surface forming the corner." } R"MillenniumOS: Probe Vise Corner" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Vise corner probe aborted!" }

--- a/sys/mos-vars.g
+++ b/sys/mos-vars.g
@@ -26,8 +26,12 @@ global mosDebug=false
 ; These can be overridden in mos-user-vars.g if necessary (but almost certainly do not need to be).
 
 ; Relative to the operator, where is the corner to be probed?
-; This is a global because it is used by both G6520 and G6508
-global mosCnr = {"Front Left", "Front Right", "Back Right", "Back Left"}
+; If your machine axes move in the opposite directions, you can rename or
+; reorder these options to match your machine correctly.
+global mosCornerNames = {"Front Left", "Front Right", "Back Right", "Back Left"}
+
+; Relative to the workpiece, where is the surface to be probed?
+global mosSurfaceNames = {"Left","Right","Front","Back","Top"}
 
 ; Store additional tool information.
 ; Values are: [radius, {deflection-x, deflection-y}]


### PR DESCRIPTION
Also rename the variables so they're slightly more readable now that memory on stm32f4 is slightly less of an issue.