### PR TITLE
Fix work offset passed to `G6600` in `AT_START` probe mode

### DIFF
--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -497,12 +497,9 @@ function onOpen() {
     if(getProperty("jobWCSProbeMode") === wcsProbeMode.ATSTART) {
       writeln("")
       for(var i = 0; i < seenWCS.length; i++) {
-        // MillenniumOS uses 1-indexed WCS numbers.
-        // WCS 1 is G54, WCS 2 is G55, etc.
-        // Fusion360 uses _offsets_, which are 0-indexed.
-        var wcs = seenWCS[i]+1;
-        writeComment("Probe origin and save in WCS {wcs}".supplant({wcs: wcs}));
-        writeBlock(gCodesF.format(G.PROBE_OPERATOR), "W{wcs}".supplant({wcs: wcs}));
+        var offset = seenWCS[i];
+        writeComment("Probe origin and save in WCS {wcs}".supplant({wcs: offset+1}));
+        writeBlock(gCodesF.format(G.PROBE_OPERATOR), "W{offset}".supplant({offset: offset}));
         writeln("");
       }
     } else {


### PR DESCRIPTION
`AT_START` probe mode in the Fusion360 post-processor was not updated when we started using zero-indexed workplace offsets to set origins of the workplaces at the start of a job.

