### PR TITLE
fusion: job-notes popup

### DIFF
--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -548,6 +548,9 @@ var curTool = {
   coolant: "disabled"
 }
 
+// Track values containing details about the job notes.
+var jobNotes = '';
+
 // Handle parameters.
 function onParameter(param, value) {
   switch(param) {
@@ -592,7 +595,10 @@ function onParameter(param, value) {
     case 'operation:tool_spindleSpeed':
       curTool['rpm'] = value;
     break;
-
+    // Save Job Notes
+    case 'job-notes':
+      jobNotes = value;
+    break;
     // Generate errors on unsupported parameter values
     case 'operation:tool_clockwise':
       if(value !== 1) {
@@ -661,6 +667,7 @@ function onSection() {
     writeComment("Switch to WCS {wcs}".supplant(workOffsetF));
     writeBlock(gCodes.format(wcsCode));
     writeln("");
+    if(jobNotes !== '') writeConfirmableDialog(jobNotes);
     if(doProbe) {
       writeComment("Probe origin in current WCS");
       writeBlock(gCodesF.format(G.PROBE_OPERATOR));


### PR DESCRIPTION
This allows you to add notes to your setup and pop them up just before probing.

![RwOfRgl 1](https://github.com/user-attachments/assets/430eb205-4983-49fc-95e8-066d7375c807)

![iuLFrZB 1](https://github.com/user-attachments/assets/41ec66e4-8122-415b-a888-3ce96fbbf309)

If you don't add any notes, no popup:

![CSJ1aPg 1](https://github.com/user-attachments/assets/080c4307-aad9-45d7-83ae-9ce3773aa280)
