### PR TITLE
Make probe retries available to non-tutorial mode

### DIFF
--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -155,8 +155,10 @@ if { var.workOffset != null }
             ; This is a recursive call. Let the user break it :)
             G6600 W{var.workOffset}
 
-    elif { global.mosTM }
-        M291 P{"WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetCodes[var.workOffset] ^ ") origin is valid.<br/>Click <b>Continue</b> to proceed or <b>Re-Probe</b> to try again."} R"MillenniumOS: Probe Workpiece" T0 S4 K{"Continue", "Re-Probe"}
-        if { input == 1 }
+    elif { !global.mosEM }
+        M291 P{"WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetCodes[var.workOffset] ^ ") origin is valid.<br/>Click <b>Continue</b> to proceed or <b>Re-Probe</b> to try again."} R"MillenniumOS: Probe Workpiece" T0 S4 K{"Continue", "Re-Probe", "Cancel"}
+        if { input == 3 }
+            abort { "Operator cancelled probe cycle!" }
+        elif { input == 1 }
             ; This is a recursive call. Let the user break it :)
             G6600 W{var.workOffset}


### PR DESCRIPTION
This allows normal mode to retry probing operations if say the probe misses the right place to touch off from. It remains disabled in expert mode.

Also adds a cancel button to abort if something else is seriously wrong.