### PR TITLE
Separate surface clearance and corner clearance

### DIFF
--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -62,13 +62,28 @@ if { var.pocketLength < 1 }
     abort { "Pocket length too low!" }
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surfaces we start probing from, to account for any innaccuracy in the center location." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surfaces and corners we probe from, to account for any innaccuracy in the start position." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Rectangle pocket probe aborted!" }
 
-var clearance = { input }
-if { var.clearance < 1 }
+var surfaceClearance = { input }
+
+if { var.surfaceClearance <= 0.1 }
     abort { "Clearance distance too low!" }
+
+; Calculate the maximum clearance distance we can use before
+; the probe points will be flipped
+var mC = { min(var.pocketWidth, var.pocketLength) / 2 }
+
+var cornerClearance = null
+
+if { var.surfaceClearance >= var.mC }
+    var defCC = { max(1, var.mC-1) }
+    M291 P"The <b>clearance</b> distance is more than half of the length or width of the pocket.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.defCC}
+    set var.cornerClearance = { input }
+    if { var.cornerClearance >= var.mC }
+        abort { "Corner clearance distance too high!" }
+
 
 ; Prompt for overtravel distance
 M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surfaces to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{global.mosOT}
@@ -98,4 +113,4 @@ if { global.mosTM }
     if { input != 0 }
         abort { "Rectangle pocket probe aborted!" }
 
-G6502.1 W{var.workOffset} H{var.pocketWidth} I{var.pocketLength} T{var.clearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6502.1 W{var.workOffset} H{var.pocketWidth} I{var.pocketLength} T{var.surfaceClearance} C{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -17,6 +17,15 @@ if { !exists(param.J) || !exists(param.K) || !exists(param.L) }
 if { !exists(param.H) || !exists(param.I) }
     abort { "Must provide an approximate width and length using H and I parameters!" }
 
+if { exists(param.T) && param.T != null && param.T <= 0 }
+    abort { "Surface clearance distance must be greater than 0!" }
+
+if { exists(param.C) && param.C != null && param.C <= 0 }
+    abort { "Corner clearance distance must be greater than 0!" }
+
+if { exists(param.O) && param.O != null && param.O <= 0 }
+    abort { "Overtravel distance must be greater than 0!" }
+
 ; Default workOffset to the current workplace number if not specified
 ; with the W parameter.
 var workOffset = { (exists(param.W) && param.W != null) ? param.W : move.workplaceNumber }
@@ -77,7 +86,7 @@ var surfaceClearance = { (exists(param.T) ? param.T : global.mosCL) + ((state.cu
 
 ; Default corner clearance to the normal clearance
 ; distance, but allow it to be overridden if necessary.
-var cornerClearance = { (exists(param.N) ? param.N : (exists(param.T) ? param.T : global.mosCL)) }
+var cornerClearance = { (exists(param.C) ? ((param.C != null) ? param.C : (exists(param.T) ? ((param.T != null) ? param.T : global.mosCL)))) }
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -82,11 +82,11 @@ var hL   = { var.fL/2 }
 ; make sure the surface of the tool and the workpiece
 ; are the clearance distance apart, rather than less
 ; than that.
-var surfaceClearance = { (exists(param.T) ? param.T : global.mosCL) + ((state.currentTool < #tools && state.currentTool >= 0) ? global.mosTT[state.currentTool][0] : 0) }
+var surfaceClearance = { ((!exists(param.T) || param.T == null) ? global.mosCL : param.T) + ((state.currentTool < #tools && state.currentTool >= 0) ? global.mosTT[state.currentTool][0] : 0) }
 
 ; Default corner clearance to the normal clearance
 ; distance, but allow it to be overridden if necessary.
-var cornerClearance = { (exists(param.C) ? ((param.C != null) ? param.C : (exists(param.T) ? ((param.T != null) ? param.T : global.mosCL)))) }
+var cornerClearance = { (!exists(param.C) || param.C == null) ? ((!exists(param.T) || param.T == null) ? global.mosCL : param.T) : param.C }
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact
@@ -103,7 +103,7 @@ var overtravel = { (exists(param.O) ? param.O : global.mosOT) - ((state.currentT
 ; the expected corners, a clearance higher than
 ; the width or height would mean we would try to
 ; probe off the edge of the block.
-if { (var.cornerClearance * 2) >= var.fW || (var.cornerClearance * 2) >= var.fL }
+if { var.cornerClearance >= var.hW || var.cornerClearance >= var.hL }
     abort { "Corner clearance distance is more than half of the width or height of the block! Cannot probe." }
 
 ; The overtravel distance does not have the same

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -66,9 +66,9 @@ M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away fr
 if { result != 0 }
     abort { "Rectangle block probe aborted!" }
 
-var clearance = { input }
+var surfaceClearance = { input }
 
-if { var.clearance <= 0.1 }
+if { var.surfaceClearance <= 0.1 }
     abort { "Clearance distance too low!" }
 
 ; Calculate the maximum clearance distance we can use before
@@ -77,7 +77,7 @@ var mC = { min(var.blockWidth, var.blockLength) / 2 }
 
 var cornerClearance = null
 
-if { var.clearance >= var.mC }
+if { var.surfaceClearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
     M291 P"The <b>clearance</b> distance is more than half of the length or width of the block.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.defCC}
     set var.cornerClearance = { input }
@@ -112,4 +112,4 @@ if { global.mosTM }
     if { input != 0 }
         abort { "Rectangle block probe aborted!" }
 
-G6503.1 W{var.workOffset} H{var.blockWidth} I{var.blockLength} T{var.clearance} C{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6503.1 W{var.workOffset} H{var.blockWidth} I{var.blockLength} T{var.surfaceClearance} C{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -79,7 +79,7 @@ var cornerClearance = null
 
 if { var.clearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
-    M291 P"The <b>clearance</b> distance you entered is more than half of the length or width of the block.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.defCC}
+    M291 P"The <b>clearance</b> distance is more than half of the length or width of the block.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.defCC}
     set var.cornerClearance = { input }
     if { var.cornerClearance >= var.mC }
         abort { "Corner clearance distance too high!" }
@@ -112,4 +112,4 @@ if { global.mosTM }
     if { input != 0 }
         abort { "Rectangle block probe aborted!" }
 
-G6503.1 W{var.workOffset} H{var.blockWidth} I{var.blockLength} T{var.clearance} N{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6503.1 W{var.workOffset} H{var.blockWidth} I{var.blockLength} T{var.clearance} C{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -90,7 +90,7 @@ if { result != 0 }
 var surfaceClearance = { input }
 
 if { var.surfaceClearance <= 0.1 }
-    abort { "Surface clearance distance too low!" }
+    abort { "Clearance distance too low!" }
 
 ; Calculate the maximum clearance distance we can use before
 ; the probe points will be flipped
@@ -101,10 +101,9 @@ var cornerClearance = null
 if { var.surfaceClearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
     M291 P"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.defCC}
-    set var.cnrClearance = { input }
-    if { var.cnrClearance >= var.mC }
+    set var.cornerClearance = { input }
+    if { var.cornerClearance >= var.mC }
         abort { "Corner clearance distance too high!" }
-
 
 ; Prompt for overtravel distance
 M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{global.mosOT}
@@ -141,4 +140,4 @@ if { global.mosTM }
     if { input != 0 }
         abort { "Outside corner probe aborted!" }
 
-G6508.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.cnr} T{var.SurfaceClearance} C{var.cnrClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}
+G6508.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.cnr} T{var.SurfaceClearance} C{var.cornerClearance} O{var.overtravel} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition - var.probingDepth}

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -24,7 +24,6 @@ if { !exists(param.I) }
 ; with the W parameter.
 var workOffset = { (exists(param.W) && param.W != null) ? param.W : move.workplaceNumber }
 
-
 ; WCS Numbers and Offsets are confusing. Work Offset indicates the offset
 ; from the first work co-ordinate system, so is 0-indexed. WCS number indicates
 ; the number of the work co-ordinate system, so is 1-indexed.

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -34,6 +34,15 @@ if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) 
 if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCornerNames) }
     abort { "Must provide a valid corner index using the N parameter!" }
 
+if { exists(param.T) && param.T != null && param.T <= 0 }
+    abort { "Surface clearance distance must be greater than 0!" }
+
+if { exists(param.C) && param.C != null && param.C <= 0 }
+    abort { "Corner clearance distance must be greater than 0!" }
+
+if { exists(param.O) && param.O != null && param.O <= 0 }
+    abort { "Overtravel distance must be greater than 0!" }
+
 ; Default workOffset to the current workplace number if not specified
 ; with the W parameter.
 var workOffset = { (exists(param.W) && param.W != null) ? param.W : move.workplaceNumber }
@@ -75,7 +84,7 @@ if { global.mosWPSfcPos[var.workOffset] == global.mosDfltWPSfcPos || global.mosW
     abort { "G6520: Failed to probe the top surface of the workpiece!" }
 
 ; Probe the corner surface
-G6508.1 R0 W{var.workOffset} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{ global.mosWPSfcPos[var.workOffset] - param.P }
+G6508.1 R0 W{var.workOffset} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} C{param.C} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{ global.mosWPSfcPos[var.workOffset] - param.P }
 if { global.mosWPCnrNum[var.workOffset] == null }
     abort { "G6520: Failed to probe the corner surface of the workpiece!" }
 

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -52,9 +52,9 @@ var workOffset = { (exists(param.W) && param.W != null) ? param.W : move.workpla
 ; the number of the work co-ordinate system, so is 1-indexed.
 var wcsNumber = { var.workOffset + 1 }
 
-M291 P{"Please select the probing mode to use.<br/><b>Full</b> will probe 2 points on each horizontal surface, while <b>Quick</b> will probe only 1 point."} R"MillenniumOS: Probe Outside Corner" T0 S4 K{"Full","Quick"} F0
+M291 P{"Please select the probing mode to use.<br/><b>Full</b> will probe 2 points on each horizontal surface, while <b>Quick</b> will probe only 1 point."} R"MillenniumOS: Probe Vise Corner" T0 S4 K{"Full","Quick"} F0
 if { result != 0 }
-    abort { "Outside corner probe aborted!" }
+    abort { "Vise corner probe aborted!" }
 
 var mode = { input }
 
@@ -85,13 +85,28 @@ if { var.mode == 0 }
         abort { "Y surface length too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
 
 ; Prompt for clearance distance
-M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surface we start probing from, to account for any innaccuracy in the corner location." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosCL}
+M291 P"Please enter <b>clearance</b> distance in mm.<br/>This is how far away from the expected surfaces and corners we probe from, to account for any innaccuracy in the start position." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosCL}
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
-var clearance = { input }
-if { var.clearance < var.tR }
-    abort { Clearance distance too low. Cannot probe distances smaller than the tool radius (" ^ var.tR ^ ")!"}
+var surfaceClearance = { input }
+
+if { var.surfaceClearance <= 0.1 }
+    abort { "Clearance distance too low!" }
+
+var cornerClearance = null
+
+if { var.mode == 0 }
+    ; Calculate the maximum clearance distance we can use before
+    ; the probe points will be flipped
+    var mC = { min(var.xSL, var.ySL) / 2 }
+
+    if { var.surfaceClearance >= var.mC }
+        var defCC = { max(1, var.mC-1) }
+        M291 P"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.defCC}
+        set var.cornerClearance = { input }
+        if { var.cornerClearance >= var.mC }
+            abort { "Corner clearance distance too high!" }
 
 ; Prompt for overtravel distance
 M291 P"Please enter <b>overtravel</b> distance in mm.<br/>This is how far we move past the expected surface to account for any innaccuracy in the dimensions." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosOT}
@@ -110,7 +125,7 @@ M291 P"Please select the corner to probe.<br/><b>NOTE</b>: These surface names a
 if { result != 0 }
     abort { "Vise corner probe aborted!" }
 
-var corner = { input }
+var cnr = { input }
 
 M291 P"Please enter the depth to probe at in mm, relative to the top surface of the workpiece. A value of 10 will move the probe downwards 10mm before probing inwards." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{global.mosOT}
 if { result != 0 }
@@ -123,9 +138,9 @@ if { var.probeDepth < 0 }
 
 ; Run the block probe cycle
 if { global.mosTM }
-    var cN = { global.mosCornerNames[var.corner] }
+    var cN = { global.mosCornerNames[var.cnr] }
     M291 P{"We will now probe the top surface, then move outside the <b>" ^ var.cN ^ "</b> corner, down " ^ var.probeDepth ^ "mm, and probe each surface forming the corner." } R"MillenniumOS: Probe Vise Corner" T0 S4 K{"Continue", "Cancel"} F0
     if { input != 0 }
         abort { "Vise corner probe aborted!" }
 
-G6520.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.corner} T{var.clearance} O{var.overtravel} P{var.probeDepth} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}
+G6520.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.cnr} T{var.surfaceClearance} C{var.cornerClearance} O{var.overtravel} P{var.probeDepth} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{move.axes[2].machinePosition}


### PR DESCRIPTION
This is intended to fix #104, and also remove a minor bug where the clearance value has the tool radius applied to it. This is necessary for the _surface_ clearance (i.e. how far away from a target surface we start the probing move) but is _not_ necessary for the _corner_ clearance (i.e. how far away from the expected corners of a surface we place the probe).

