### PR TITLE
Set the toolsetter Z when probing datum tool

### DIFF
--- a/macro/movement/G37.g
+++ b/macro/movement/G37.g
@@ -126,12 +126,27 @@ else
 ; offset from there instead.
 
 var toolOffset = 0
+
+; If touch probe is configured, then our offset is relative to the activation
+; point distance from the reference surface.
 if { global.mosFeatTouchProbe }
     set var.toolOffset = { -(var.aP - global.mosTSAP) }
+
+; Otherwise, if we're probing the probe tool (datum tool in this case since
+; the touch probe is disabled), then we store the activation point against
+; which subsequent tools will be offset - but we do not set an offset for
+; the datum tool itself.
+elif { global.mosPTID == state.currentTool }
+    set global.mosTSP[2] = { var.aP }
+    echo {"Datum Tool Reference Position=" ^ global.mosTSP[2] ^ "mm"}
+
+; If we're probing a normal cutting tool, then we calculate the offset
+; based on the previously probed datum tool activation point.
 else
     set var.toolOffset = { -(abs(global.mosTSP[2]) - abs(var.aP)) }
 
-echo {"Tool #" ^ state.currentTool ^ " Offset=" ^ var.toolOffset ^ "mm"}
+if { var.toolOffset != 0 }
+    echo {"Tool #" ^ state.currentTool ^ " Offset=" ^ var.toolOffset ^ "mm"}
 
 ; Park spindle in Z ready for next operation
 G27 Z1

--- a/macro/movement/G37.g
+++ b/macro/movement/G37.g
@@ -137,13 +137,13 @@ if { global.mosFeatTouchProbe }
 ; which subsequent tools will be offset - but we do not set an offset for
 ; the datum tool itself.
 elif { global.mosPTID == state.currentTool }
-    set global.mosTSP[2] = { var.aP }
-    echo {"Datum Tool Reference Position=" ^ global.mosTSP[2] ^ "mm"}
+    set global.mosTSAP = { var.aP }
+    echo {"Toolsetter Activation Point =" ^ global.mosTSAP ^ "mm"}
 
-; If we're probing a normal cutting tool, then we calculate the offset
-; based on the previously probed datum tool activation point.
 else
-    set var.toolOffset = { -(abs(global.mosTSP[2]) - abs(var.aP)) }
+    ; If we're probing a normal cutting tool, then we calculate the offset
+    ; based on the previously probed datum tool activation point.
+    set var.toolOffset = { -(abs(global.mosTSAP) - abs(var.aP)) }
 
 if { var.toolOffset != 0 }
     echo {"Tool #" ^ state.currentTool ^ " Offset=" ^ var.toolOffset ^ "mm"}


### PR DESCRIPTION
It seems there have been a large number of issues related to inaccurate Z height or machines going out of limits. This appears to be down to issues with how the Z offset was calculated, using the original position of the toolsetter as probed during the wizard to calculate an offset for the datum tool itself, and then for any subsequent tools.

We now set the toolsetter Z position when the datum tool is probed rather than giving it an offset, and then set offsets on subsequent tools based on the probed activation point.