### PR TITLE
Do not assign spindle to probe tools

### DIFF
--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -411,7 +411,7 @@ if { var.wizFeatureToolSetter }
 
         ; Add a wizard datum tool using the provided radius
         ; Use a temporary spindle ID for the wizard spindle
-        M4000 S{"Wizard Datum Tool"} P{global.mosPTID} R{ var.wizDatumToolRadius } I{var.wizSpindleID}
+        M4000 S{"Wizard Datum Tool"} P{global.mosPTID} R{ var.wizDatumToolRadius } I{null}
 
         ; Switch to the datum tool but don't run any macros
         ; as we already know the datum tool is installed.
@@ -605,7 +605,7 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
 
     ; Add a wizard touch probe using the provided radius
     ; Use a temporary spindle ID for the wizard spindle
-    M4000 S{"Wizard Touch Probe"} P{global.mosPTID} R{ var.wizTouchProbeRadius } I{var.wizSpindleID}
+    M4000 S{"Wizard Touch Probe"} P{global.mosPTID} R{ var.wizTouchProbeRadius } I{null}
 
     ; Switch to the probe tool.
     T{global.mosPTID} P0

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -411,7 +411,7 @@ if { var.wizFeatureToolSetter }
 
         ; Add a wizard datum tool using the provided radius
         ; Use a temporary spindle ID for the wizard spindle
-        M4000 S{"Wizard Datum Tool"} P{global.mosPTID} R{ var.wizDatumToolRadius } I{null}
+        M4000 S{"Wizard Datum Tool"} P{global.mosPTID} R{ var.wizDatumToolRadius } I{-1}
 
         ; Switch to the datum tool but don't run any macros
         ; as we already know the datum tool is installed.
@@ -605,7 +605,7 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
 
     ; Add a wizard touch probe using the provided radius
     ; Use a temporary spindle ID for the wizard spindle
-    M4000 S{"Wizard Touch Probe"} P{global.mosPTID} R{ var.wizTouchProbeRadius } I{null}
+    M4000 S{"Wizard Touch Probe"} P{global.mosPTID} R{ var.wizTouchProbeRadius } I{-1}
 
     ; Switch to the probe tool.
     T{global.mosPTID} P0

--- a/macro/public/3. Config/Settings/Toggle Touch Probe.g
+++ b/macro/public/3. Config/Settings/Toggle Touch Probe.g
@@ -14,11 +14,11 @@ set global.mosFeatTouchProbe = {!global.mosFeatTouchProbe}
 
 ; Switch probe tool name and configuration when toggling touch probe
 if { global.mosFeatTouchProbe }
-    M4000 P{global.mosPTID} S{"Touch Probe"} R{global.mosTPR} I{null}
+    M4000 P{global.mosPTID} S{"Touch Probe"} R{global.mosTPR} I{-1}
 else
     ; Reset toolsetter activation point as this is used to store
     ; the datum tool Z position when touch probe is disabled.
     set global.mosTSAP = null
-    M4000 P{global.mosPTID} S{"Datum Tool"} R{global.mosDTR} I{null}
+    M4000 P{global.mosPTID} S{"Datum Tool"} R{global.mosDTR} I{-1}
 
 echo {"MillenniumOS: Touch Probe " ^ (global.mosFeatTouchProbe ? "Enabled" : "Disabled")}

--- a/macro/public/3. Config/Settings/Toggle Touch Probe.g
+++ b/macro/public/3. Config/Settings/Toggle Touch Probe.g
@@ -14,11 +14,11 @@ set global.mosFeatTouchProbe = {!global.mosFeatTouchProbe}
 
 ; Switch probe tool name and configuration when toggling touch probe
 if { global.mosFeatTouchProbe }
-    M4000 P{global.mosPTID} S{"Touch Probe"} R{global.mosTPR}
+    M4000 P{global.mosPTID} S{"Touch Probe"} R{global.mosTPR} I{null}
 else
     ; Reset toolsetter activation point as this is used to store
     ; the datum tool Z position when touch probe is disabled.
     set global.mosTSAP = null
-    M4000 P{global.mosPTID} S{"Datum Tool"} R{global.mosDTR}
+    M4000 P{global.mosPTID} S{"Datum Tool"} R{global.mosDTR} I{null}
 
 echo {"MillenniumOS: Touch Probe " ^ (global.mosFeatTouchProbe ? "Enabled" : "Disabled")}

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -34,14 +34,14 @@ if { global.mosFeatTouchProbe }
 
     ; Add a touch probe tool at the last index in the tool table.
     ; Make sure to specify deflection values for compensation.
-    M4000 S{"Touch Probe"} P{global.mosPTID} R{global.mosTPR} X{global.mosTPD[0]} Y{global.mosTPD[1]} I{null}
+    M4000 S{"Touch Probe"} P{global.mosPTID} R{global.mosTPR} X{global.mosTPD[0]} Y{global.mosTPD[1]} I{-1}
 else
     if { !exists(global.mosDTR) || global.mosDTR == null }
         set global.mosErr = { "<b>global.mosDTR</b> is not set." }
         M99
 
     ; Add a datum tool at the last index in the tool table.
-    M4000 S{"Datum Tool"} P{global.mosPTID} R{global.mosDTR} I{null}
+    M4000 S{"Datum Tool"} P{global.mosPTID} R{global.mosDTR} I{-1}
 
 ; If we have a toolsetter, make sure the relevant variables are set
 if { global.mosFeatToolSetter }

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -34,14 +34,14 @@ if { global.mosFeatTouchProbe }
 
     ; Add a touch probe tool at the last index in the tool table.
     ; Make sure to specify deflection values for compensation.
-    M4000 S{"Touch Probe"} P{global.mosPTID} R{global.mosTPR} X{global.mosTPD[0]} Y{global.mosTPD[1]}
+    M4000 S{"Touch Probe"} P{global.mosPTID} R{global.mosTPR} X{global.mosTPD[0]} Y{global.mosTPD[1]} I{null}
 else
     if { !exists(global.mosDTR) || global.mosDTR == null }
         set global.mosErr = { "<b>global.mosDTR</b> is not set." }
         M99
 
     ; Add a datum tool at the last index in the tool table.
-    M4000 S{"Datum Tool"} P{global.mosPTID} R{global.mosDTR}
+    M4000 S{"Datum Tool"} P{global.mosPTID} R{global.mosDTR} I{null}
 
 ; If we have a toolsetter, make sure the relevant variables are set
 if { global.mosFeatToolSetter }


### PR DESCRIPTION
`M4000` already allowed spindle IDs to be passed when creating tools, to allow a tool to be assigned to a spindle but this defaults to the spindle configured in MillenniumOS.

By setting the `I` parameter to `null`, we should assign the tool without a spindle so that it cannot be controlled via M3.9 or M5.9.
Signed-off-by: Ben Agricola <ben+git@agrico.la>