### PR TITLE
Fix spindle stopped check in canned cycles

### DIFF
--- a/macro/movement/G73.g
+++ b/macro/movement/G73.g
@@ -13,8 +13,7 @@ if { global.mosCCD == null }
     if { !exists(param.Z) }
         abort { "Must specify Z position (Z...)" }
 
-
-if { spindles[global.mosSID].active <= 0 }
+if { spindles[global.mosSID].current == 0 }
     abort { "Cannot run canned cycle with spindle off!" }
 
 ; Default the Z position to the previously stored mosCCD value

--- a/macro/movement/G81.g
+++ b/macro/movement/G81.g
@@ -10,7 +10,7 @@ if { global.mosCCD == null }
     if { !exists(param.Z) }
         abort { "Must specify Z position (Z...)" }
 
-if { spindles[global.mosSID].active <= 0 }
+if { spindles[global.mosSID].current == 0 }
     abort { "Cannot run canned cycle with spindle off!" }
 
 ; Default the Z position to the previously stored mosCCD value

--- a/macro/movement/G83.g
+++ b/macro/movement/G83.g
@@ -13,7 +13,7 @@ if { global.mosCCD == null }
     if { !exists(param.Z) }
         abort { "Must specify Z position (Z...)" }
 
-if { spindles[global.mosSID].active <= 0 }
+if { spindles[global.mosSID].current == 0 }
     abort { "Cannot run canned cycle with spindle off!" }
 
 ; Default the Z position to the previously stored mosCCD value


### PR DESCRIPTION
Turns out if the spindle is switched off but has been configured with an RPM, then the active field will reflect that RPM even though the spindle is stopped. We now check the absolute value of the current field instead.