### PR TITLE
Fix corner clearance dialog popup

### DIFF
--- a/macro/movement/G6502.g
+++ b/macro/movement/G6502.g
@@ -79,7 +79,7 @@ var cornerClearance = null
 
 if { var.surfaceClearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
-    M291 P"The <b>clearance</b> distance is more than half of the length or width of the pocket.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.defCC}
+    M291 P{"The <b>clearance</b> distance is more than half of the length or width of the pocket.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>."} R"MillenniumOS: Probe Rect. Pocket" J1 T0 S6 F{var.defCC}
     set var.cornerClearance = { input }
     if { var.cornerClearance >= var.mC }
         abort { "Corner clearance distance too high!" }

--- a/macro/movement/G6503.g
+++ b/macro/movement/G6503.g
@@ -79,7 +79,7 @@ var cornerClearance = null
 
 if { var.surfaceClearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
-    M291 P"The <b>clearance</b> distance is more than half of the length or width of the block.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.defCC}
+    M291 P{"The <b>clearance</b> distance is more than half of the length or width of the block.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>."} R"MillenniumOS: Probe Rect. Block" J1 T0 S6 F{var.defCC}
     set var.cornerClearance = { input }
     if { var.cornerClearance >= var.mC }
         abort { "Corner clearance distance too high!" }

--- a/macro/movement/G6508.g
+++ b/macro/movement/G6508.g
@@ -100,7 +100,7 @@ var cornerClearance = null
 
 if { var.surfaceClearance >= var.mC }
     var defCC = { max(1, var.mC-1) }
-    M291 P"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.defCC}
+    M291 P{"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>."} R"MillenniumOS: Probe Outside Corner" J1 T0 S6 F{var.defCC}
     set var.cornerClearance = { input }
     if { var.cornerClearance >= var.mC }
         abort { "Corner clearance distance too high!" }

--- a/macro/movement/G6520.g
+++ b/macro/movement/G6520.g
@@ -103,7 +103,7 @@ if { var.mode == 0 }
 
     if { var.surfaceClearance >= var.mC }
         var defCC = { max(1, var.mC-1) }
-        M291 P"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>." R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.defCC}
+        M291 P{"The <b>clearance</b> distance is more than half of the length of one of the corner surfaces.<br/>Please enter a <b>corner clearance</b> distance less than <b>" ^ var.mC ^ "</b>."} R"MillenniumOS: Probe Vise Corner" J1 T0 S6 F{var.defCC}
         set var.cornerClearance = { input }
         if { var.cornerClearance >= var.mC }
             abort { "Corner clearance distance too high!" }


### PR DESCRIPTION
The dialog string for the corner clearance prompt was not wrapped in `{}` so would not display, prompting a corner clearance error.

We additionally would generate a pointless error if the distance to target was less than the probing move back-off value, if the probe was triggered. The probe should be safe to move less than its back-off value regardless of triggering so we now just move to the target, allowing the `G38.3` to become a no-op.