### PR TITLE
Enable low memory mode by default in F360

### DIFF
--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -211,7 +211,7 @@ properties = {
     group: "configuration",
     scope: "post",
     type: "boolean",
-    value: false
+    value: true
   }
 };
 


### PR DESCRIPTION
Hopefully this will avoid further issues with CDYv3 users.