### PR TITLE
Save WCS origins between reboots

### DIFF
--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -154,6 +154,7 @@ if { var.workOffset != null }
         if { input == 0 }
             ; This is a recursive call. Let the user break it :)
             G6600 W{var.workOffset}
+            M99
 
     else
         M291 P{"WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetCodes[var.workOffset] ^ ") origin is valid.<br/>Click <b>Continue</b> to proceed or <b>Re-Probe</b> to try again."} R"MillenniumOS: Probe Workpiece" T0 S4 K{"Continue", "Re-Probe", "Cancel"}
@@ -162,3 +163,8 @@ if { var.workOffset != null }
         elif { input == 1 }
             ; This is a recursive call. Let the user break it :)
             G6600 W{var.workOffset}
+            M99
+
+    ; Save work offsets to config-override.g
+    M500
+    echo { "MillenniumOS: WCS Origins have been saved and will be restored on reboot."}

--- a/macro/public/4. Misc/WCS Origins/Persist WCS Origins.g
+++ b/macro/public/4. Misc/WCS Origins/Persist WCS Origins.g
@@ -1,0 +1,5 @@
+; Persist WCS Origins.g
+;
+; Save work offsets to config-override.g
+M500
+echo { "MillenniumOS: WCS Origins have been saved and will be restored on reboot."}

--- a/macro/public/4. Misc/WCS Origins/Reset WCS Origins.g
+++ b/macro/public/4. Misc/WCS Origins/Reset WCS Origins.g
@@ -1,0 +1,12 @@
+; Reset WCS Origins.g
+;
+; Reset all WCS origins.
+while { iterations < limits.workplaces }
+    G10 L2 P{iterations} X0 Y0 Z0
+end
+
+; Reset any other settings
+M502
+
+; Save the config-override.g file
+M500

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -155,14 +155,14 @@ parser.add_argument('--version-check', action=argparse.BooleanOptionalAction, de
     to make sure the post-processor version and MillenniumOS version installed
     in RRF match.
     """)
-probe_mode = parser.add_mutually_exclusive_group(required=False)
+probe_mode = parser.add_mutually_exclusive_group(required=False, default=PROBE.ON_CHANGE)
 probe_mode.add_argument('--probe-at-start', dest='probe_mode', action='store_const', const=PROBE.AT_START,
     help="When enabled, MillenniumOS will probe a work-piece in each used WCS prior to executing any operations.")
 
 probe_mode.add_argument('--probe-on-change', dest='probe_mode', action='store_const', const=PROBE.ON_CHANGE,
     help="When enabled, MillenniumOS will probe a work-piece just prior to switching into each used WCS.")
 
-probe_mode.add_argument('--no-probe', dest='probe_mode', action='store_const', default=PROBE.NONE)
+probe_mode.add_argument('--no-probe', dest='probe_mode', action='store_const', const=PROBE.NONE)
 
 parser.add_argument(
     "--vssc-period",

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -956,7 +956,7 @@ class MillenniumOSPostProcessor(PostProcessor):
         return super().output()
 
 # Parse and export the CAM objects.
-def export(objectslist, filename, argstring):
+def export(objectslist, _, argstring):
     try:
         args = parser.parse_args(shlex.split(argstring))
     except Exception as e:
@@ -976,5 +976,4 @@ def export(objectslist, filename, argstring):
     if FreeCAD.GuiUp and args.show_editor:
         out = PostUtils.editor(out)
 
-    with open(filename, "w") as f:
-        f.write(out)
+    return out

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -155,8 +155,8 @@ parser.add_argument('--version-check', action=argparse.BooleanOptionalAction, de
     to make sure the post-processor version and MillenniumOS version installed
     in RRF match.
     """)
-probe_mode = parser.add_mutually_exclusive_group(required=False, default=PROBE.ON_CHANGE)
-probe_mode.add_argument('--probe-at-start', dest='probe_mode', action='store_const', const=PROBE.AT_START,
+probe_mode = parser.add_mutually_exclusive_group(required=False)
+probe_mode.add_argument('--probe-at-start', dest='probe_mode', action='store_const', const=PROBE.AT_START, default=PROBE.ON_CHANGE,
     help="When enabled, MillenniumOS will probe a work-piece in each used WCS prior to executing any operations.")
 
 probe_mode.add_argument('--probe-on-change', dest='probe_mode', action='store_const', const=PROBE.ON_CHANGE,

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -69,6 +69,9 @@ if { !exists(global.mosSDS) || global.mosSDS == null }
     set global.mosErr = { "<b>global.mosSDS</b> is not set." }
     M99
 
+; Load settings saved with M500
+M501
+
 ; Allow MOS macros to run.
 set global.mosLdd = true
 


### PR DESCRIPTION
It can sometimes be helpful to have WCS origins saved between reboots. This can be achieved very easily with the `M500` command, so we now load override settings on boot using `M501` and save these using `M500` at the end of `G6600` (probe workpiece).

These can also be saved manually using a macro, from the `Misc` folder.