### PR TITLE
Allow VSSC in reverse, and fix FreeCAD post error

### DIFF
--- a/macro/private/run-vssc.g
+++ b/macro/private/run-vssc.g
@@ -15,7 +15,7 @@ if { !exists(global.mosLdd) || !global.mosLdd }
 ; if the correct time has passed.
 
 ; If spindle is not active or speed is zero, return
-if { spindles[global.mosSID].state != "forward" || spindles[global.mosSID].active == 0 }
+if { (spindles[global.mosSID].state != "forward" && spindles[global.mosSID].state != "reverse") || spindles[global.mosSID].active == 0 }
     M99 ; Return, spindle is not active or stationary
 
 ; Use uptime to get millisecond precision

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -331,7 +331,7 @@ class Output:
             if k in self.varFormats:
                 for o in self.varFormats[k]:
                     argOut, _ = o(v)
-                    if argOut is not None:
+                    if argOut is not None and len(argOut) > 0:
                         outCmd.append(''.join(argOut[0]))
                         # Store index in cmd list of changed key
                         # Necessary because we don't always output


### PR DESCRIPTION
VSSC was not enabled if spindle was in reverse (it is still not possible to start the spindle in reverse via gcode but this will come later).

We also fix a minor FreeCAD output error.