### PR TITLE
Use v3.6-dev feed rate override on probing moves

### DIFF
--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -49,6 +49,7 @@ M6515 X{ var.tP[0] } Y{ var.tP[1] } Z{ var.tP[2] }
 ; to restore the probe speed after completing each probe.
 var roughSpeed   = { sensors.probes[param.I].speeds[0] }
 var fineSpeed    = { sensors.probes[param.I].speeds[1] }
+var curSpeed     = { var.roughSpeed }
 
 var roughDivider = 5
 
@@ -57,9 +58,6 @@ if { var.roughSpeed == var.fineSpeed }
     if { !global.mosEM }
         echo { "MillenniumOS: Probe " ^ param.I ^ " is configured with a single feed rate, which will be used for the initial probe. Subsequent probes will run at " ^ var.fineSpeed ^ "mm/min." }
         echo { "MillenniumOS: Please use M558 K" ^ param.I ^ " F" ^ var.roughSpeed ^ ":" ^ var.fineSpeed ^ " in your config to silence this warning." }
-
-; Set rough probe speed
-M558 K{ param.I } F{ var.roughSpeed }
 
 ; These variables are used within the probing loop to calculate
 ; average positions and variances of the probed points.
@@ -87,11 +85,9 @@ while { iterations <= var.retries }
     ; activated at one probe point.
 
     if { var.errors }
-        G53 G38.2 K{ param.I } X{ var.tP[0] } Y{ var.tP[1] } Z{ var.tP[2] }
+        G53 G38.2 K{ param.I } F{ var.curSpeed } X{ var.tP[0] } Y{ var.tP[1] } Z{ var.tP[2] }
         ; Abort if an error was encountered
         if { result != 0 }
-            ; Reset probing speed limits
-            M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
 
             ; Park at Z max.
             ; This is a safety precaution to prevent subsequent X/Y moves from
@@ -101,7 +97,7 @@ while { iterations <= var.retries }
             abort { "G6512.1: Probe " ^ param.I ^ " experienced an error, aborting!" }
     else
         ; Disable errors by using G38.3
-        G53 G38.3 K{ param.I } X{ var.tP[0] } Y{ var.tP[1] } Z{ var.tP[2] }
+        G53 G38.3 K{ param.I } F{ var.curSpeed } X{ var.tP[0] } Y{ var.tP[1] } Z{ var.tP[2] }
 
     ; Get current machine position
     M5000 P0
@@ -144,7 +140,7 @@ while { iterations <= var.retries }
             set var.pV[2] = { var.nS[2] / (iterations-1) }
 
     ; Drop to fine probing speed
-    M558 K{ param.I } F{ var.fineSpeed }
+    set var.curSpeed = { var.fineSpeed }
 
     ; If we have not moved from the starting position, do not back off.
     ; bN will return NaN if the start and current positions are the same
@@ -200,9 +196,6 @@ while { iterations <= var.retries }
     ; Dwell so machine can settle, if necessary
     if { sensors.probes[param.I].recoveryTime > 0.0 }
         G4 P{ ceil(sensors.probes[param.I].recoveryTime * 1000) }
-
-; Reset probing speed limits
-M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
 
 if { !exists(global.mosMI) }
     global mosMI = { null }

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -128,16 +128,11 @@ if { sensors.probes[param.I].value[0] != 0 }
     if { sensors.probes[param.I].value[0] != 0 }
         abort {"G6550: Probe is still triggered after backing off by " ^ global.mosPMBO ^ "mm. You will need to manually move the probe out of harms way!" }
 
-M558 K{ param.I } F{ sensors.probes[param.I].travelSpeed }
-
 ; Move to position while checking probe for activation
-G53 G38.3 K{ param.I } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
+G53 G38.3 K{ param.I } F{ sensors.probes[param.I].travelSpeed } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
 ; Wait for moves to complete
 M400
-
-; Reset probe speed
-M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
 
 ; Probing move either complete or stopped due to collision, we need to
 ; check the location of the machine to determine if the move was completed.


### PR DESCRIPTION
Requires RRF `v3.6` to function. Do not merge before `v3.6` is released! 