### PR TITLE
Allow tools to persist when jobs finish

### DIFF
--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -19,6 +19,22 @@ if { !exists(param.P) || !exists(param.R) || !exists(param.S) }
 if { param.P >= limits.tools || param.P < 0 }
     abort { "Tool index must be between 0 and " ^ limits.tools-1 ^ "!" }
 
+; Check if tool is already defined and matches. If so, skip adding it.
+; This allows us to re-run a file that defines the tool that is currently
+; loaded, without unloading the tool.
+; This has to be split over multiple lines due to length of the condition.
+var toolSame = { global.mosTT[param.P][0] == param.R && tools[param.P].spindle == ((exists(param.I)) ? param.I : global.mosSID) }
+
+set var.toolSame = { var.toolSame && tools[param.P].name == param.S }
+
+if { exists(param.X) }
+    set var.toolSame = { var.toolSame && global.mosTT[param.P][1][0] == param.X }
+if { exists(param.Y) }
+    set var.toolSame = { var.toolSame && global.mosTT[param.P][1][1] == param.Y }
+
+if { var.toolSame }
+    M99
+
 ; Define RRF tool against spindle.
 ; Allow spindle ID to be overridden where necessary using I parameter.
 ; This is mainly used during the configuration wizard.

--- a/post-processors/freecad/millennium_os_post.py
+++ b/post-processors/freecad/millennium_os_post.py
@@ -904,8 +904,7 @@ class MillenniumOSPostProcessor(PostProcessor):
                 self.comment("Pass tool details to firmware")
                 # Output tool info
                 for index, tool in tools.items():
-                    tool_desc = ' '.join([tool['name'], "F={flutes} L={flute_length} CR={corner_radius}".format(**tool['params'])])
-                    self.M(MCODES.ADD_TOOL, P=index, R=tool['params']['radius'], S=rrf_safe_string(tool_desc), ctrl=Control.FORCE)
+                    self.M(MCODES.ADD_TOOL, P=index, R=tool['params']['radius'], S=rrf_safe_string(tool['name'][:32]), ctrl=Control.FORCE)
                 self.brk()
 
             # Output job setup commands if necessary

--- a/post-processors/fusion-360/millennium-os.cps
+++ b/post-processors/fusion-360/millennium-os.cps
@@ -465,14 +465,11 @@ function onOpen() {
     writeComment("Pass tool details to firmware");
     for(var i = 0; i < nTools; i++) {
       var tool = tools.getTool(i);
-      writeBlock('{cmd} P{index} R{radius} S"{desc} F={f} L={l} CR={cr}"'.supplant({
+      writeBlock('{cmd} P{index} R{radius} S"{desc}"'.supplant({
         cmd: mCodes.format(M.ADD_TOOL),
         index: intFmt.format(tool.number),
         radius: axesFmt.format(tool.diameter/2),
-        desc: tool.description,
-        l: axesFmt.format(tool.fluteLength),
-        cr: axesFmt.format(tool.cornerRadius),
-        f: intFmt.format(tool.numberOfFlutes)
+        desc: tool.description.substring(0, 32),
       }));
     }
     writeln("");

--- a/sys/stop.g
+++ b/sys/stop.g
@@ -4,6 +4,3 @@
 ; Apparently also triggered when pausing.
 ; Park the spindle.
 G27
-
-; Deselect the current tool.
-T-1


### PR DESCRIPTION
It can be a pain having to re-probe a tool that was already loaded and had its offset calculated.

This happened because the tool would be unloaded in `stop.g` (at the end of a job), but also if a tool _was_ already selected and a gcode file was run that contained a `M4000` command for the loaded tool, then that tool would be redefined - which caused it to be unloaded.

This PR forces `M4000` to return if the current tool matches the existing one, with the caveat that RRF tools are truncated internally to 32 characters. Since we can only directly compare strings, not substrings, we must make sure the post-processors truncate tool names to 32 characters as well for this comparison to work.
