### PR TITLE
Disable rotation compensation when probing

### DIFF
--- a/macro/machine/M5011.g
+++ b/macro/machine/M5011.g
@@ -14,19 +14,25 @@ if { var.workOffset < 0 || var.workOffset >= limits.workplaces }
     abort { "Work Offset (W..) must be between 0 and " ^ limits.workplaces-1 ^ "!" }
 
 
-if { global.mosWPDeg[var.workOffset] != global.mosDfltWPDeg }
+if { global.mosWPDeg[var.workOffset] != global.mosDfltWPDeg && global.mosWPCtrPos[var.workOffset] != global.mosDfltWPCtrPos }
+
+    var cX = { global.mosWPCtrPos[var.workOffset][0] }
+    var cY = { global.mosWPCtrPos[var.workOffset][1] }
+
     if { !global.mosEM }
-        M291 P{"Workpiece in WCS " ^ var.wcsNumber ^ " is rotated by " ^ global.mosWPDeg[var.workOffset] ^ " degrees. Apply compensation?"} R{"MillenniumOS: Workpiece Rotation Compensation"} S4 K{"Yes","No"} F0
+        M291 P{"Workpiece in WCS " ^ var.wcsNumber ^ " is rotated by " ^ global.mosWPDeg[var.workOffset] ^ " degrees around X=" ^ var.cX ^ " Y=" ^ var.cY ^ ". Apply compensation?"} R{"MillenniumOS: Workpiece Rotation Compensation"} S4 K{"Yes","No"} F0
         if { input != 0 }
             echo { "MillenniumOS: Rotation compensation not applied."}
             ; Cancel any existing rotation applied
             G69
             M99
 
+    ; Calculate center position relative to WCS origin.
+    ; For a rectangle block probe this should produce X=0 Y=0.
     ; Rotate the workpiece around the origin.
-    G68 X0 Y0 R{global.mosWPDeg[var.workOffset]}
+    G68 X{ var.cX - move.axes[0].workplaceOffsets[var.workOffset] } Y{ var.cY - move.axes[1].workplaceOffsets[var.workOffset] } R{ global.mosWPDeg[var.workOffset] }
 
-    echo { "MillenniumOS: Rotation compensation of " ^ -global.mosWPDeg[var.workOffset] ^ " degrees applied around origin" }
+    echo { "MillenniumOS: Rotation compensation of " ^ -global.mosWPDeg[var.workOffset] ^ " degrees applied around X=" ^ var.cX ^ " Y=" ^ var.cY }
 else
     ; Cancel any existing rotation applied
     G69

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -46,8 +46,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite
-; Reset center position and radius
-M5010 W{var.workOffset} R5
+; Reset center position, rotation and radius
+M5010 W{var.workOffset} R37
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -42,8 +42,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite -
-; center and radius
-M5010 W{var.workOffset} R5
+; center position, rotation and radius
+M5010 W{var.workOffset} R37
 
 ; Get current machine position on Z
 M5000 P1 I2

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -36,8 +36,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite -
-; surface
-M5010 W{var.workOffset} R8
+; surface and rotation
+M5010 W{var.workOffset} R40
 
 ; Get current machine position on Z
 M5000 P1 I2

--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -29,6 +29,11 @@ G90
 G21
 G94
 
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
+
 ; Get current machine position
 M5000 P0
 

--- a/macro/movement/G6512.2.g
+++ b/macro/movement/G6512.2.g
@@ -18,8 +18,10 @@ G90
 G21
 G94
 
-; Make sure machine is stationary before checking machine positions
-M400
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
 
 ; Get current machine position
 M5000 P0

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -36,6 +36,16 @@ if { !exists(param.X) && !exists(param.Y) && !exists(param.Z) }
 
 var manualProbe = { !exists(param.I) || param.I == null }
 
+; Use absolute positions in mm and feeds in mm/min
+G90
+G21
+G94
+
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
+
 ; Get current machine position
 M5000 P0
 
@@ -51,11 +61,6 @@ if { var.tPX == global.mosMI[0] && var.tPY == global.mosMI[1] && var.tPZ == glob
 
 ; Check if the positions are within machine limits
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
-
-; Use absolute positions in mm and feeds in mm/min
-G90
-G21
-G94
 
 ; If we're using "manual" probing, we can't
 ; protect any moves as we have no inputs to check.
@@ -133,17 +138,14 @@ M558 K{ param.I } F{ sensors.probes[param.I].travelSpeed }
 ; Move to position while checking probe for activation
 G53 G38.3 K{ param.I } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
-; Wait for moves to complete
-M400
-
-; Reset probe speed
-M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
+; Get current machine position
+M5000 P0
 
 ; Probing move either complete or stopped due to collision, we need to
 ; check the location of the machine to determine if the move was completed.
 
-; Get current machine position
-M5000 P0
+; Reset probe speed
+M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
 
 var tolerance = { 0.005 }
 


### PR DESCRIPTION
Previously, rotation compensation would be enabled if probing a WCS with a rotation value already set - however, protected moves and probe moves would be run without compensation because of being used with `G53`. 

This would cause an issue with position comparisons, because we are unable to read a non-rotated position - so these might fail because it would appear like we had not reached our expected positions.

We fix this by making sure that rotation compensation is disabled before probing or protected moves.

We also make sure to reset rotation values on probing cycles that cannot calculate a rotation value, and clean up some calls to `M400` before `M5000` which are unnecessary because `M5000` calls `M400` internally.

Fixes #167 