### PR TITLE
Modify rotation compensation and probing behaviour

### DIFF
--- a/macro/machine/M5011.g
+++ b/macro/machine/M5011.g
@@ -13,20 +13,25 @@ var wcsNumber = { var.workOffset + 1 }
 if { var.workOffset < 0 || var.workOffset >= limits.workplaces }
     abort { "Work Offset (W..) must be between 0 and " ^ limits.workplaces-1 ^ "!" }
 
+var hasRotation = { global.mosWPDeg[var.workOffset] != global.mosDfltWPDeg }
+var hasCentre   = { global.mosWPCtrPos[var.workOffset][0] != global.mosDfltWPCtrPos[0] && global.mosWPCtrPos[var.workOffset][1] != global.mosDfltWPCtrPos[1] }
 
-if { global.mosWPDeg[var.workOffset] != global.mosDfltWPDeg }
-    if { !global.mosEM }
-        M291 P{"Workpiece in WCS " ^ var.wcsNumber ^ " is rotated by " ^ global.mosWPDeg[var.workOffset] ^ " degrees. Apply compensation?"} R{"MillenniumOS: Workpiece Rotation Compensation"} S4 K{"Yes","No"} F0
-        if { input != 0 }
-            echo { "MillenniumOS: Rotation compensation not applied."}
-            ; Cancel any existing rotation applied
-            G69
-            M99
+if { var.hasRotation && var.hasCentre }
+
+    var cX = { global.mosWPCtrPos[var.workOffset][0] }
+    var cY = { global.mosWPCtrPos[var.workOffset][1] }
+
+    M291 P{"Workpiece in WCS " ^ var.wcsNumber ^ " is rotated by " ^ global.mosWPDeg[var.workOffset] ^ " degrees. Apply compensation?"} R{"MillenniumOS: Workpiece Rotation Compensation"} S4 K{"Yes","No"} F0
+    if { input != 0 }
+        echo { "MillenniumOS: Rotation compensation not applied."}
+        ; Cancel any existing rotation applied
+        G69
+        M99
 
     ; Rotate the workpiece around the origin.
     G68 X0 Y0 R{global.mosWPDeg[var.workOffset]}
 
-    echo { "MillenniumOS: Rotation compensation of " ^ -global.mosWPDeg[var.workOffset] ^ " degrees applied around origin" }
+    echo { "MillenniumOS: Rotation compensation of " ^ global.mosWPDeg[var.workOffset] ^ " degrees applied around origin" }
 else
     ; Cancel any existing rotation applied
     G69

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -46,8 +46,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite
-; Reset center position and radius
-M5010 W{var.workOffset} R5
+; Reset center position, rotation and radius
+M5010 W{var.workOffset} R37
 
 ; Apply tool radius to overtravel. We want to allow
 ; less movement past the expected point of contact

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -42,8 +42,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite -
-; center and radius
-M5010 W{var.workOffset} R5
+; center position, rotation and radius
+M5010 W{var.workOffset} R37
 
 ; Get current machine position on Z
 M5000 P1 I2

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -299,11 +299,28 @@ if { var.pMO == 0 }
     elif { var.aR < -45 }
         set var.aR = { var.aR + 90 }
 
-    set global.mosWPDeg[var.workOffset] = { var.aR }
+    set global.mosWPDeg[var.workOffset] = { -var.aR }
 
     ; Calculate the center of the workpiece based on the corner position,
     ; the width and height of the workpiece and the rotation.
-    set global.mosWPCtrPos[var.workOffset] = { var.cX + ((var.fX/2) * cos(radians(var.aR)) - (var.fY/2) * sin(radians(var.aR))), var.cY + ((var.fX/2) * sin(radians(var.aR)) + (var.fY/2) * cos(radians(var.aR))) }
+    ; FL = Add width and height
+    ; FR = Subtract width and add height
+    ; BL = Add width and subtract height
+    ; BR = Subtract width and height
+
+    var cDistX = { (var.fX/2) * cos(radians(var.aR)) - (var.fY/2) * sin(radians(var.aR)) }
+    var cDistY = { (var.fX/2) * sin(radians(var.aR)) + (var.fY/2) * cos(radians(var.aR)) }
+
+    var ctrX = { var.cX }
+    var ctrY = { var.cY }
+
+    var deltaX = { (param.N == 0 || param.N == 3) ? var.cDistX : -var.cDistX }
+    var deltaY = { (param.N == 0 || param.N == 1) ? var.cDistY : -var.cDistY }
+
+    set var.ctrX = { var.ctrX + deltaX }
+    set var.ctrY = { var.ctrY + deltaY }
+
+    set global.mosWPCtrPos[var.workOffset] = { var.ctrX, var.ctrY }
 
     ; If running in full mode, operator provided approximate width and
     ; height values of the workpiece. Assign these to the global

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -240,7 +240,8 @@ if { var.pMO == 0 }
     ; and var.pY[0] -> var.pY[1], and the Y surface is defined
     ; by the line var.pX[2] -> var.pX[3] and var.pY[2] -> var.pY[3].
 
-    ; Calculate normals for both lines
+    ; Calculate normals (gradient) for both lines
+    ; Using the formula m = (y2 - y1) / (x2 - x1)
     var mX = { (var.pY[1] - var.pY[0]) / (var.pX[1] - var.pX[0]) }
     var mY = { (var.pY[3] - var.pY[2]) / (var.pX[3] - var.pX[2]) }
 
@@ -311,16 +312,12 @@ if { var.pMO == 0 }
     var cDistX = { (var.fX/2) * cos(radians(var.aR)) - (var.fY/2) * sin(radians(var.aR)) }
     var cDistY = { (var.fX/2) * sin(radians(var.aR)) + (var.fY/2) * cos(radians(var.aR)) }
 
-    var ctrX = { var.cX }
-    var ctrY = { var.cY }
+    if { param.N == 1 || param.N == 2 }
+        set var.cDistX = { -(var.cDistX) }
+    if { param.N == 2 || param.N == 3 }
+        set var.cDistY = { -(var.cDistY) }
 
-    var deltaX = { (param.N == 0 || param.N == 3) ? var.cDistX : -var.cDistX }
-    var deltaY = { (param.N == 0 || param.N == 1) ? var.cDistY : -var.cDistY }
-
-    set var.ctrX = { var.ctrX + deltaX }
-    set var.ctrY = { var.ctrY + deltaY }
-
-    set global.mosWPCtrPos[var.workOffset] = { var.ctrX, var.ctrY }
+    set global.mosWPCtrPos[var.workOffset] = { var.cX + var.cDistX, var.cY + var.cDistY }
 
     ; If running in full mode, operator provided approximate width and
     ; height values of the workpiece. Assign these to the global

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -36,8 +36,8 @@ if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
 ; Reset stored values that we're going to overwrite -
-; surface
-M5010 W{var.workOffset} R8
+; surface and rotation
+M5010 W{var.workOffset} R40
 
 ; Get current machine position on Z
 M5000 P1 I2

--- a/macro/movement/G6512.1.g
+++ b/macro/movement/G6512.1.g
@@ -29,6 +29,11 @@ G90
 G21
 G94
 
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
+
 ; Get current machine position
 M5000 P0
 

--- a/macro/movement/G6512.2.g
+++ b/macro/movement/G6512.2.g
@@ -18,8 +18,10 @@ G90
 G21
 G94
 
-; Make sure machine is stationary before checking machine positions
-M400
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
 
 ; Get current machine position
 M5000 P0

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -58,15 +58,6 @@ var probeId = { global.mosFeatTouchProbe ? global.mosTPID : null }
 if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
 
-; Store our own safe Z position as the current position. We return to
-; this position where necessary to make moves across the workpiece to
-; the next probe point.
-; We do this _after_ any switch to the touch probe, because while the
-; original position may have been safe with a different tool installed,
-; the touch probe may be longer. After a tool change the spindle
-; will be parked, so essentially our safeZ is at the parking location.
-var safeZ = { move.axes[2].machinePosition }
-
 ; Above the corner to be probed
 ; J = start position X
 ; K = start position Y
@@ -78,13 +69,19 @@ var sZ   = { param.L }
 ; Specify R0 so that the underlying macros dont report their own
 ; debug info.
 
+; Get current machine position
+M5000 P0
+
 ; Probe the top surface of the workpiece from the current Z position
-G6510.1 R0 W{var.workOffset} H4 I{param.T} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{var.safeZ}
+G6510.1 R0 W{var.workOffset} H4 I{param.T} O{param.O} J{global.mosMI[0]} K{global.mosMI[1]} L{global.mosMI[2]}
 if { global.mosWPSfcPos[var.workOffset] == global.mosDfltWPSfcPos || global.mosWPSfcAxis[var.workOffset] != "Z" }
     abort { "G6520: Failed to probe the top surface of the workpiece!" }
 
+; Get current machine position
+M5000 P0
+
 ; Probe the corner surface
-G6508.1 R0 W{var.workOffset} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} C{param.C} O{param.O} J{move.axes[0].machinePosition} K{move.axes[1].machinePosition} L{ global.mosWPSfcPos[var.workOffset] - param.P }
+G6508.1 R0 W{var.workOffset} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} C{param.C} O{param.O} J{global.mosMI[0]} K{global.mosMI[1]} L{ global.mosWPSfcPos[var.workOffset] - param.P }
 if { global.mosWPCnrNum[var.workOffset] == null }
     abort { "G6520: Failed to probe the corner surface of the workpiece!" }
 

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -36,6 +36,16 @@ if { !exists(param.X) && !exists(param.Y) && !exists(param.Z) }
 
 var manualProbe = { !exists(param.I) || param.I == null }
 
+; Use absolute positions in mm and feeds in mm/min
+G90
+G21
+G94
+
+; Cancel rotation compensation as we use G53 on the probe move.
+; Leaving rotation compensation active causes us to fail position
+; checks.
+G69
+
 ; Get current machine position
 M5000 P0
 
@@ -51,11 +61,6 @@ if { var.tPX == global.mosMI[0] && var.tPY == global.mosMI[1] && var.tPZ == glob
 
 ; Check if the positions are within machine limits
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
-
-; Use absolute positions in mm and feeds in mm/min
-G90
-G21
-G94
 
 ; If we're using "manual" probing, we can't
 ; protect any moves as we have no inputs to check.
@@ -133,17 +138,14 @@ M558 K{ param.I } F{ sensors.probes[param.I].travelSpeed }
 ; Move to position while checking probe for activation
 G53 G38.3 K{ param.I } X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
-; Wait for moves to complete
-M400
-
-; Reset probe speed
-M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
+; Get current machine position
+M5000 P0
 
 ; Probing move either complete or stopped due to collision, we need to
 ; check the location of the machine to determine if the move was completed.
 
-; Get current machine position
-M5000 P0
+; Reset probe speed
+M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
 
 var tolerance = { 0.005 }
 

--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -96,13 +96,14 @@ if { global.mosTM }
 ; If work offset origin is already set
 if { var.pdX != 0 && var.pdY != 0 && var.pdZ != 0 }
     ; Allow operator to continue without resetting the origin and abort the probe
-    M291 P{"WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetName ^ ") already has a valid origin.<br/>Click <b>Continue</b> to use the existing origin or <b>Re-Probe</b> to modify it."} R"MillenniumOS: Probe Workpiece" T0 S4 K{"Continue","Re-Probe"} F0
+    M291 P{"WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetName ^ ") is valid. <br/><b>Continue</b> to proceed, <b>Modify</b> to update or <b>Reset</b> to start again."} R"MillenniumOS: Probe Workpiece" T0 S4 K{"Continue","Modify", "Reset"} F0
     if { input == 0 }
         echo {"MillenniumOS: WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetName ^ ") origin retained, skipping probe cycle."}
         M99
-
-    ; Reset the WCS origin so that all axes must be re-probed.
-    G10 L2 P{var.wcsNumber} X0 Y0 Z0
+    elif { input == 2 }
+        echo {"MillenniumOS: WCS " ^ var.wcsNumber ^ " (" ^ var.workOffsetName ^ ") origin has been reset."}
+        ; Reset the WCS origin so that all axes must be re-probed.
+        G10 L2 P{var.wcsNumber} X0 Y0 Z0
 
 ; Switch to touchprobe if not already connected
 if { global.mosPTID != state.currentTool }

--- a/macro/movement/G6600.g
+++ b/macro/movement/G6600.g
@@ -105,6 +105,9 @@ if { var.pdX != 0 && var.pdY != 0 && var.pdZ != 0 }
         ; Reset the WCS origin so that all axes must be re-probed.
         G10 L2 P{var.wcsNumber} X0 Y0 Z0
 
+        ; Clear all stored WCS details
+        M5010 W{var.workOffset}
+
 ; Switch to touchprobe if not already connected
 if { global.mosPTID != state.currentTool }
     T T{global.mosPTID}
@@ -113,6 +116,9 @@ if { global.mosPTID != state.currentTool }
 M291 P"Please select a probe cycle type." R"MillenniumOS: Probe Workpiece" T0 S4 F0 K{var.probeCycleNames}
 if { result != 0 }
     abort { "Operator cancelled probe cycle!" }
+
+; Cancel rotation compensation as we use G53 on the probe moves.
+G69
 
 ; Run the selected probing operation.
 ; We cannot lookup G command numbers to run dynamically so these must be


### PR DESCRIPTION
- Do not automatically apply rotation compensation in expert mode, prompt all users
- Only apply compensation around the work-piece centre point. This should make rotation more accurate for corner probes that previously rotated around the corner.
- Cancel rotation compensation in various places where it would otherwise impact probing
- Update Vice Corner probe input to use `M5000 P0` to get machine position
- Allow valid origins to be updated rather than used or cleared