### PR TITLE
Do not try to access pwm state on null gpOut pins

### DIFF
--- a/sys/pause.g
+++ b/sys/pause.g
@@ -3,7 +3,8 @@
 ; Save pre-pause state of all general purpose
 ; output pins.
 while { iterations < #state.gpOut }
-    set global.mosPS[iterations] = state.gpOut[iterations].pwm
+    if { state.gpOut[iterations] != null }
+        set global.mosPS[iterations] = state.gpOut[iterations].pwm
 
 ; Raise the spindle to the top of the Z axis and
 ; then stop it, but do not move the table.


### PR DESCRIPTION
`reached null object before end of selector string` occurred if there were gaps in the `gpOut` entries in the object model.

We fix this by not trying to read null entries in the table.