### PR TITLE
Adding in control for Air, Mist and Flood coolant on cancel

### DIFF
--- a/sys/cancel.g
+++ b/sys/cancel.g
@@ -1,0 +1,8 @@
+if { global.mosCAID != null  }
+  M42 P{global.mosCAID} S0
+
+if { global.mosCMID != null }
+  M42 P{global.mosCMID) S0
+
+if { global.mosCFID != null }
+  M42 P{global.mosCFID} S0

--- a/sys/cancel.g
+++ b/sys/cancel.g
@@ -1,8 +1,2 @@
-if { global.mosCAID != null  }
-  M42 P{global.mosCAID} S0
-
-if { global.mosCMID != null }
-  M42 P{global.mosCMID) S0
-
-if { global.mosCFID != null }
-  M42 P{global.mosCFID} S0
+; Call M9 for Coolant Control
+M9

--- a/sys/stop.g
+++ b/sys/stop.g
@@ -4,3 +4,6 @@
 ; Apparently also triggered when pausing.
 ; Park the spindle.
 G27
+
+; Disable Coolant 
+M9

--- a/sys/stop.g
+++ b/sys/stop.g
@@ -4,6 +4,3 @@
 ; Apparently also triggered when pausing.
 ; Park the spindle.
 G27
-
-; Disable Coolant 
-M9


### PR DESCRIPTION
Noticed that coolant pins weren't being turned off on cancel/fault.
This is an attempt to turn off off pins via the cancel.g file