### PR TITLE
Check for null tool before tool comparisons

### DIFF
--- a/macro/machine/M4000.g
+++ b/macro/machine/M4000.g
@@ -23,17 +23,18 @@ if { param.P >= limits.tools || param.P < 0 }
 ; This allows us to re-run a file that defines the tool that is currently
 ; loaded, without unloading the tool.
 ; This has to be split over multiple lines due to length of the condition.
-var toolSame = { global.mosTT[param.P][0] == param.R && tools[param.P].spindle == ((exists(param.I)) ? param.I : global.mosSID) }
+if { global.mosTT[param.P] != null && tools[param.P] != null }
+    var toolSame = { global.mosTT[param.P][0] == param.R && tools[param.P].spindle == ((exists(param.I)) ? param.I : global.mosSID) }
 
-set var.toolSame = { var.toolSame && tools[param.P].name == param.S }
+    set var.toolSame = { var.toolSame && tools[param.P].name == param.S }
 
-if { exists(param.X) }
-    set var.toolSame = { var.toolSame && global.mosTT[param.P][1][0] == param.X }
-if { exists(param.Y) }
-    set var.toolSame = { var.toolSame && global.mosTT[param.P][1][1] == param.Y }
+    if { exists(param.X) }
+        set var.toolSame = { var.toolSame && global.mosTT[param.P][1][0] == param.X }
+    if { exists(param.Y) }
+        set var.toolSame = { var.toolSame && global.mosTT[param.P][1][1] == param.Y }
 
-if { var.toolSame }
-    M99
+    if { var.toolSame }
+        M99
 
 ; Define RRF tool against spindle.
 ; Allow spindle ID to be overridden where necessary using I parameter.


### PR DESCRIPTION
Fixes `reached null object before end of selector string` issues when trying to define a tool in an empty slot.