### PR TITLE
Throw error if probe not selected in execution macro

### DIFF
--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -46,7 +46,7 @@ var pID = { global.mosFeatTouchProbe ? global.mosTPID : null }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Reset stored values that we're going to overwrite -
 ; center position, rotation and radius

--- a/macro/movement/G6502.1.g
+++ b/macro/movement/G6502.1.g
@@ -46,7 +46,7 @@ var pID = { global.mosFeatTouchProbe ? global.mosTPID : null }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Reset stored values that we're going to overwrite -
 ; center, dimensions and rotation

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -46,7 +46,7 @@ var pID = { global.mosFeatTouchProbe ? global.mosTPID : null }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Reset stored values that we're going to overwrite -
 ; center, dimensions and rotation

--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -53,7 +53,7 @@ set global.mosPRPT = { global.mosPRPT + (var.pFull ? 4 : 2) }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Reset stored values that we're going to overwrite
 ; Reset corner, dimensions and rotation

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -37,7 +37,7 @@ var pID = { global.mosFeatTouchProbe ? global.mosTPID : null }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Reset stored values that we're going to overwrite -
 ; surface and rotation

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -56,7 +56,7 @@ var probeId = { global.mosFeatTouchProbe ? global.mosTPID : null }
 
 ; Make sure probe tool is selected
 if { global.mosPTID != state.currentTool }
-    T T{global.mosPTID}
+    abort { "Must run T" ^ global.mosPTID ^ " to select the probe tool before probing!" }
 
 ; Specify R0 so that the underlying macros dont report their own
 ; debug info.


### PR DESCRIPTION
If the operator somehow managed to execute the underlying execution macros (`G6500.1`, `G6508.1`, `G6520.1`) without having the probe tool selected, following the toolchange procedure would cause the probe cycle to continue from the retraction point above the reference surface.

It should not be possible to reach this state without executing gcodes manually but we should abort if we find ourselves in this position so we avoid any probing issues.