### PR TITLE
Rename instead of deleting discarded restore points

### DIFF
--- a/macro/machine/M501.1.g
+++ b/macro/machine/M501.1.g
@@ -13,7 +13,7 @@ if { fileexists("0:/sys/" ^ var.restoreFile) }
             M291 P{"Restore point loaded. Please check the selected WCS, loaded tool and WCS origins <b>CAREFULLY</b> before continuing!"} R"MillenniumOS: Restore Point" S2 T0
             M99
 
-    M472 P{ "0:/sys/" ^ var.restoreFile }
-    echo { "MillenniumOS: Restore point has been discarded" }
+    M471 S{"/sys/" ^ var.restoreFile } T{"/sys/" ^ var.restoreFile ^ ".bak"} D1
+    echo { "MillenniumOS: Restore point has been backed up to "  ^ var.restoreFile ^ ".bak before being discarded. It will be deleted when you next discard a restore point!" }
 else
     echo { "MillenniumOS: No restore point found" }


### PR DESCRIPTION
When discarding a restore point, the file will now be renamed to append `.bak` to the filename. The next time you discard another restore point, the original `.bak` file will be overwritten.

This allows you to recover a single restore point after it has been discarded.

Fixes #181 