### PR TITLE
Call arborctl-daemon if it exists

### DIFF
--- a/macro/machine/M5000.g
+++ b/macro/machine/M5000.g
@@ -10,7 +10,7 @@ if { !inputs[state.thisInput].active }
     M99
 
 if { !exists(param.P) }
-    abort { "M5011: No machine information requested with P parameter." }
+    abort { "M5000: No machine information requested with P parameter." }
 
 if { !exists(global.mosMI) }
     global mosMI = { null }

--- a/macro/movement/G6550.g
+++ b/macro/movement/G6550.g
@@ -148,9 +148,6 @@ M5000 P0
 ; Probing move either complete or stopped due to collision, we need to
 ; check the location of the machine to determine if the move was completed.
 
-; Reset probe speed
-M558 K{ param.I } F{ var.roughSpeed, var.fineSpeed }
-
 var tolerance = { 0.005 }
 
 if { global.mosMI[0] < (var.tPX - var.tolerance) || global.mosMI[0] > (var.tPX + var.tolerance) }

--- a/sys/daemon.g
+++ b/sys/daemon.g
@@ -12,6 +12,10 @@ M98 P"mos/display-startup-messages.g"
 while { exists(global.mosDAE) && global.mosDAE }
     G4 P{global.mosDAEUR} ; Minimum interval between daemon runs
 
+    ; Run the ArborCtl daemon if it exists
+    if { fileexists("0:/sys/arborctl/arborctl-daemon.g") }
+        M98 P"arborctl/arborctl-daemon.g"
+
     ; Only run VSSC when feature is enabled and VSSC has been activated
     if { exists(global.mosFeatVSSC) && global.mosFeatVSSC == true && global.mosVSEnabled && global.mosVSOE }
         M98 P"mos/run-vssc.g" ; Update active spindle speed based on timings

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -46,7 +46,7 @@ else
 ; If we have a toolsetter, make sure the relevant variables are set
 if { global.mosFeatToolSetter }
     if { !exists(global.mosTSID) || global.mosTSID == null }
-        set global.mosErr = { "<b>global.mosTSID</b> must contain the ID of the Toolsetter probe. Configure it using M558 K[probe-id]... in config.g, then run the configuration wizard (<b>G8000</b>)." }
+        set global.mosErr = { "<b>global.mosTSID</b> must contain the ID of the Toolsetter probe. Configure it using M558 K<probe-id>... in config.g, then run the configuration wizard (<b>G8000</b>)." }
         M99
     if { !exists(global.mosTSP) || global.mosTSP == null }
         set global.mosErr = { "<b>global.mosTSP</b> is not set." }


### PR DESCRIPTION
[ArborCTL](https://github.com/MillenniumMachines/ArborCTL) is a framework to allow control of VFDs in RRF via Modbus / RS485. Since MillenniumOS defines its own `daemon.g` file, we need to call the `arborctl-daemon.g` implementation so that Modbus spindles can be controlled.