### PR TITLE
Add machine SafetyNet macro

### DIFF
--- a/macro/machine/M80.9.g
+++ b/macro/machine/M80.9.g
@@ -1,0 +1,14 @@
+; M80.9.g: Allow operator to enable ATX power on boot if configured
+; USAGE: M80.9
+
+; If no ATX power port is configured, exit
+if { state.atxPowerPort == null }
+    M99
+
+; Otherwise, check the state and prompt the operator to enable ATX power
+; if it is not already enabled.
+if { !state.atxPower }
+    M291 P{"<b>CAUTION</b>: Machine Power is currently <b>deactivated</b>. Do you want to activate power to the machine?<br/>Check the machine is in a safe state before pressing <b>Activate</b>!"} R"MillenniumOS: Safety Net" S4 K{"Activate", "Cancel"} F1
+    if { input == 0 }
+        M80
+        echo {"MillenniumOS: Safety Net - Machine Power Activated!<br/>Run <b>M81.9</b> to deactivate power."}

--- a/macro/machine/M81.9.g
+++ b/macro/machine/M81.9.g
@@ -1,0 +1,14 @@
+; M81.9.g: Allow operator to disable ATX power if configured
+; USAGE: M81.9
+
+; If no ATX power port is configured, exit
+if { state.atxPowerPort == null }
+    M99
+
+; Otherwise, check the state and prompt the operator to disable ATX power
+; if it is not already disabled.
+if { state.atxPower }
+    M291 P{"<b>CAUTION</b>: Machine Power is currently <b>activated</b>. Do you want to deactivate power to the machine?<br/>This will stop <b>ALL</b> movement and spindle activity!"} R"MillenniumOS: Safety Net" S4 K{"Deactivate", "Cancel"} F1
+    if { input == 0 }
+        M81
+        echo {"MillenniumOS: Safety Net - Machine Power Deactivated!<br/>Run <b>M80.9</b> to activate power."}

--- a/macro/public/4. Misc/Safety Net/Enable Machine Power.g
+++ b/macro/public/4. Misc/Safety Net/Enable Machine Power.g
@@ -1,0 +1,4 @@
+; Enable Machine Power.g
+;
+; Prompt operator to enable machine power if configured
+M80.9

--- a/sys/mos-boot.g
+++ b/sys/mos-boot.g
@@ -72,6 +72,9 @@ if { !exists(global.mosSDS) || global.mosSDS == null }
 ; Allow MOS macros to run.
 set global.mosLdd = true
 
+; Activate machine power if safety net is configured
+M80.9
+
 ; Conditionally load saved WCS details and tool offsets
 M501.1
 


### PR DESCRIPTION
Checks for `M80` / `M81` ATX Power configuration and will prompt for power to be enabled on boot.