### PR TITLE
Call ArborCtl to Dwell if enabled during spindle control

### DIFF
--- a/macro/machine/M4.9.g
+++ b/macro/machine/M4.9.g
@@ -114,6 +114,15 @@ if { result != 0 }
 ; is defined, for speed changes or stopping.
 var alreadyWaited = false
 
+if { exists(global.arborctlLdd) && global.arborctlLdd }
+    if { !global.mosEM }
+        if { var.sStopping }
+            echo { "MillenniumOS: Waiting for ArborCtl to report spindle #" ^ var.sID ^ " has stopped" }
+        else
+            echo { "MillenniumOS: Waiting for ArborCtl to report spindle #" ^ var.sID ^ " has reached target speed" }
+    G4.9 S{var.sID}
+    set var.alreadyWaited = true
+
 if { global.mosFeatSpindleFeedback }
     if { var.sStopping && global.mosSFSID != null }
         if { !global.mosEM }
@@ -133,8 +142,7 @@ if { global.mosFeatSpindleFeedback }
         M8004 K{global.mosSFCID} D100 W30
         set var.alreadyWaited = true
 
-if { !var.alreadyWaited }
-    if { var.dwellTime > 0 }
-        if { !global.mosEM }
-            echo { "MillenniumOS: Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to reach the target speed" }
-        G4 S{var.dwellTime}
+if { !var.alreadyWaited && var.dwellTime > 0 }
+    if { !global.mosEM }
+        echo { "MillenniumOS: Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to reach the target speed" }
+    G4 S{var.dwellTime}

--- a/macro/machine/M5.9.g
+++ b/macro/machine/M5.9.g
@@ -77,14 +77,23 @@ M5
 if { !var.doWait }
     M99
 
+var alreadyWaited = false
+
+if { exists(global.arborctlLdd) && global.arborctlLdd }
+    if { !global.mosEM }
+        echo { "MillenniumOS: Waiting for ArborCtl to report spindle #" ^ var.sID ^ " has stopped" }
+    G4.9 S{var.sID}
+    set var.alreadyWaited = true
+
 if { global.mosFeatSpindleFeedback && global.mosSFSID != null }
     if { !global.mosEM }
         echo { "MillenniumOS: Waiting for spindle #" ^ var.sID ^ " to stop" }
     ; Wait for Spindle Feedback input to change state.
     ; Wait a maximum of 30 seconds, or abort.
     M8004 K{global.mosSFSID} D100 W30
+    set var.alreadyWaited = true
 
-elif { var.dwellTime > 0 }
+if { !var.alreadyWaited && var.dwellTime > 0 }
     ; Otherwise wait for spindle to stop manually
     if { !global.mosEM }
         echo { "MillenniumOS: Waiting " ^ var.dwellTime ^ " seconds for spindle #" ^ var.sID ^ " to stop" }

--- a/macro/machine/M80.9.g
+++ b/macro/machine/M80.9.g
@@ -8,7 +8,7 @@ if { state.atxPowerPort == null }
 ; Otherwise, check the state and prompt the operator to enable ATX power
 ; if it is not already enabled.
 if { !state.atxPower }
-    M291 P{"<b>CAUTION</b>: Machine Power is currently <b>deactivated</b>. Do you want to activate power to the machine?<br/>Check the machine is in a safe state before pressing <b>Activate</b>!"} R"MillenniumOS: Safety Net" S4 K{"Activate", "Cancel"} F1
+    M291 P{"<b>CAUTION</b>: Machine Power is currently <b>deactivated</b>. Do you want to <b>activate</b> power to the machine?<br/>Check the machine is in a safe state before pressing <b>Activate</b>!"} R"MillenniumOS: Safety Net" S4 K{"Activate", "Cancel"} F1
     if { input == 0 }
         M80
         echo {"MillenniumOS: Safety Net - Machine Power Activated!<br/>Run <b>M81.9</b> to deactivate power."}

--- a/macro/public/4. Misc/Safety Net/Disable Machine Power.g
+++ b/macro/public/4. Misc/Safety Net/Disable Machine Power.g
@@ -1,0 +1,5 @@
+; Disable Machine Power.g
+;
+; Prompt operator to disable machine power if configured
+M81
+echo {"MillenniumOS: Safety Net - Machine Power Deactivated! Run <b>M80.9</b> to activate power."}


### PR DESCRIPTION
Calls `G4.9` in `M3.9`, `M4.9` and `M5.9` if ArborCtl is enabled. This waits for a spindle action transition to be reported over Modbus before returning.

