### PR TITLE
Switch to using vector-dot-product for probe deflection calculations

### DIFF
--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -76,8 +76,8 @@ var numPoints = 3
 var probePoints = { vector(var.numPoints, {null, null}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
-set var.probePoints[0][0] = {var.sX, var.sY, param.Z}
-set var.probePoints[0][1] = {var.sX + var.bR + var.overtravel, var.sY, param.Z}
+set var.probePoints[0][0][0] = {var.sX, var.sY, param.Z}
+set var.probePoints[0][0][1] = {var.sX + var.bR + var.overtravel, var.sY, param.Z}
 
 ; Generate remaining probe points
 while { iterations < var.numPoints - 1 }
@@ -87,8 +87,8 @@ while { iterations < var.numPoints - 1 }
     ; Set probe point directly with calculated positions
     ; We have to keep the lines short to avoid going over the 255 character limit
     ; So we should set each index separately
-    set var.probePoints[var.pointNo][0] = { var.sX, var.sY, param.Z }
-    set var.probePoints[var.pointNo][1] = { var.sX + (var.bR + var.overtravel) * cos(var.probeAngle), var.sY + (var.bR + var.overtravel) * sin(var.probeAngle), param.Z }
+    set var.probePoints[var.pointNo][0][0] = { var.sX, var.sY, param.Z }
+    set var.probePoints[var.pointNo][0][1] = { var.sX + (var.bR + var.overtravel) * cos(var.probeAngle), var.sY + (var.bR + var.overtravel) * sin(var.probeAngle), param.Z }
 
 ; Call G6513 to probe the points
 G6513 I{var.probeId} P{var.probePoints} S{var.safeZ} D1

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -73,7 +73,8 @@ var sY = { param.K }
 
 ; Create an array of probe points for G6513
 var numPoints = 3
-var probePoints = { vector(var.numPoints, {{null, null, null}, {null, null, null}}) }
+
+var probePoints = { vector(var.numPoints, {{{null, null, null}, {null, null, null}},}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
 set var.probePoints[0][0][0] = {var.sX, var.sY, param.Z}
@@ -91,7 +92,7 @@ while { iterations < var.numPoints - 1 }
     set var.probePoints[var.pointNo][0][1] = { var.sX + (var.bR + var.overtravel) * cos(var.probeAngle), var.sY + (var.bR + var.overtravel) * sin(var.probeAngle), param.Z }
 
 ; Call G6513 to probe the points
-G6513 I{var.probeId} P{var.probePoints} S{var.safeZ} D1
+G6513 I{var.probeId} P{var.probePoints} S{var.safeZ} D1 H1
 
 ; Extract the compensated probe points from G6513's output
 var result = { global.mosMI }

--- a/macro/movement/G6500.1.g
+++ b/macro/movement/G6500.1.g
@@ -73,7 +73,7 @@ var sY = { param.K }
 
 ; Create an array of probe points for G6513
 var numPoints = 3
-var probePoints = { vector(var.numPoints, {null, null}) }
+var probePoints = { vector(var.numPoints, {{null, null, null}, {null, null, null}}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
 set var.probePoints[0][0][0] = {var.sX, var.sY, param.Z}

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -81,7 +81,7 @@ var overtravel = { (exists(param.O) ? param.O : global.mosOT) - ((state.currentT
 ; M7500 S{"Distance Modifiers adjusted for Tool Radius - Clearance=" ^ var.clearance ^ " Overtravel=" ^ var.overtravel }
 
 ; Boss Radius
-var.bR = { (param.H / 2) }
+var bR = { (param.H / 2) }
 
 ; J = start position X
 ; K = start position Y
@@ -96,8 +96,8 @@ var numPoints = 3
 var probePoints = { vector(var.numPoints, {null, null}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
-set var.probePoints[0][0] = {var.sX + var.bR + var.clearance, var.sY, param.Z}
-set var.probePoints[0][1] = {var.sX + var.bR - var.overtravel, var.sY, param.Z}
+set var.probePoints[0][0][0] = {var.sX + var.bR + var.clearance, var.sY, param.Z}
+set var.probePoints[0][0][1] = {var.sX + var.bR - var.overtravel, var.sY, param.Z}
 
 ; Generate remaining probe points
 while { iterations < var.numPoints - 1 }
@@ -107,8 +107,8 @@ while { iterations < var.numPoints - 1 }
     ; Set probe point directly with calculated positions
     ; We have to keep the lines short to avoid going over the 255 character limit
     ; So we should set each index separately
-    set var.probePoints[var.pointNo][0] = { var.sX + (var.bR + var.clearance) * cos(var.probeAngle), var.sY + (var.bR + var.clearance) * sin(var.probeAngle), param.Z }
-    set var.probePoints[var.pointNo][1] = { var.sX + (var.bR - var.overtravel) * cos(var.probeAngle), var.sY + (var.bR - var.overtravel) * sin(var.probeAngle), param.Z }
+    set var.probePoints[var.pointNo][0][0] = { var.sX + (var.bR + var.clearance) * cos(var.probeAngle), var.sY + (var.bR + var.clearance) * sin(var.probeAngle), param.Z }
+    set var.probePoints[var.pointNo][0][1] = { var.sX + (var.bR - var.overtravel) * cos(var.probeAngle), var.sY + (var.bR - var.overtravel) * sin(var.probeAngle), param.Z }
 
 ; Call G6513 to probe the points
 G6513 I{var.pID} P{var.probePoints} S{var.safeZ}

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -91,9 +91,10 @@ var bR = { (param.H / 2) }
 var sX = { param.J }
 var sY = { param.K }
 
+
 ; Create an array of probe points for G6513
 var numPoints = 3
-var probePoints = { vector(var.numPoints, {{null, null, null}, {null, null, null}}) }
+var probePoints = { vector(var.numPoints, {{{null, null, null}, {null, null, null}},}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
 set var.probePoints[0][0][0] = {var.sX + var.bR + var.clearance, var.sY, param.Z}

--- a/macro/movement/G6501.1.g
+++ b/macro/movement/G6501.1.g
@@ -93,7 +93,7 @@ var sY = { param.K }
 
 ; Create an array of probe points for G6513
 var numPoints = 3
-var probePoints = { vector(var.numPoints, {null, null}) }
+var probePoints = { vector(var.numPoints, {{null, null, null}, {null, null, null}}) }
 
 ; Set first probe point directly (0 degrees) to avoid rounding errors
 set var.probePoints[0][0][0] = {var.sX + var.bR + var.clearance, var.sY, param.Z}

--- a/macro/movement/G6502.1.g
+++ b/macro/movement/G6502.1.g
@@ -280,7 +280,18 @@ G6550 I{var.pID} X{var.sX} Y{var.sY}
 ; rotated in relation to our axes. At this point, the angle
 ; of the entire pocket's rotation can be assumed to be the angle
 ; of the first surface on the longest edge of the pocket.
-set global.mosWPDeg[var.workOffset] = { degrees(var.pSfcX[0][2]) }
+; We need to normalise the rotation to be within +- 45 degrees
+
+var aR = { var.pSfcX[0][2] }
+
+; Reduce the angle to below +/- 45 degrees (pi/4 radians)
+while { var.aR > pi/4 || var.aR < -pi/4 }
+    if { var.aR > pi/4 }
+        set var.aR = { var.aR - pi/2 }
+    elif { var.aR < -pi/4 }
+        set var.aR = { var.aR + pi/2 }
+
+set global.mosWPDeg[var.workOffset] = { degrees(var.aR) }
 
 ; Report probe results if requested
 if { !exists(param.R) || param.R != 0 }

--- a/macro/movement/G6503.1.g
+++ b/macro/movement/G6503.1.g
@@ -284,7 +284,18 @@ G6550 I{var.pID} X{var.sX} Y{var.sY}
 ; rotated in relation to our axes. At this point, the angle
 ; of the entire block's rotation can be assumed to be the angle
 ; of the first surface on the longest edge of the block.
-set global.mosWPDeg[var.workOffset] = { degrees(var.pSfcX[0][2]) }
+; We need to normalise the rotation to be within +- 45 degrees
+
+var aR = { var.pSfcX[0][2] }
+
+; Reduce the angle to below +/- 45 degrees (pi/4 radians)
+while { var.aR > pi/4 || var.aR < -pi/4 }
+    if { var.aR > pi/4 }
+        set var.aR = { var.aR - pi/2 }
+    elif { var.aR < -pi/4 }
+        set var.aR = { var.aR + pi/2 }
+
+set global.mosWPDeg[var.workOffset] = { degrees(var.aR) }
 
 ; Report probe results if requested
 if { !exists(param.R) || param.R != 0 }

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -79,16 +79,10 @@ else
 ; Check if the positions are within machine limits
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
-; Create a single surface with a single probe point for G6513
-var probePoints = { vector(1, {{null, null, null}, {null, null, null}}) }
+var probePoints = {{{{param.J, param.K, param.L}, {var.tPX, var.tPY, var.tPZ}},}, }
 
-set var.probePoints[0][0][0] = { param.J, param.K, param.L }
-set var.probePoints[0][0][1] = { var.tPX, var.tPY, var.tPZ }
-
-; Run probing operation using G6513
+; Run probing operation using G6513 with direct vector creation
 G6513 I{var.pID} P{var.probePoints} S{var.safeZ} D1
-
-echo { "Probe Points: " ^ var.probePoints }
 
 var sAxis = { (var.probeAxis <= 1)? "X" : (var.probeAxis <= 3)? "Y" : "Z" }
 
@@ -96,7 +90,7 @@ var sAxis = { (var.probeAxis <= 1)? "X" : (var.probeAxis <= 3)? "Y" : "Z" }
 set global.mosWPSfcAxis[var.workOffset] = { var.sAxis }
 
 ; Set surface position on relevant axis
-set global.mosWPSfcPos[var.workOffset] = { (var.probeAxis <= 1)? global.mosMI[0][0][0] : (var.probeAxis <= 3)? global.mosMI[0][0][1] : global.mosMI[0][0][2] }
+set global.mosWPSfcPos[var.workOffset] = { (var.probeAxis <= 1)? global.mosMI[0][0][0][0] : (var.probeAxis <= 3)? global.mosMI[0][0][0][1] : global.mosMI[0][0][0][2] }
 
 ; Report probe results if requested
 if { !exists(param.R) || param.R != 0 }

--- a/macro/movement/G6510.1.g
+++ b/macro/movement/G6510.1.g
@@ -79,8 +79,16 @@ else
 ; Check if the positions are within machine limits
 M6515 X{ var.tPX } Y{ var.tPY } Z{ var.tPZ }
 
-; Run probing operation
-G6512 I{var.pID} J{param.J} K{param.K} L{param.L} X{var.tPX} Y{var.tPY} Z{var.tPZ}
+; Create a single surface with a single probe point for G6513
+var probePoints = { vector(1, {{null, null, null}, {null, null, null}}) }
+
+set var.probePoints[0][0][0] = { param.J, param.K, param.L }
+set var.probePoints[0][0][1] = { var.tPX, var.tPY, var.tPZ }
+
+; Run probing operation using G6513
+G6513 I{var.pID} P{var.probePoints} S{var.safeZ} D1
+
+echo { "Probe Points: " ^ var.probePoints }
 
 var sAxis = { (var.probeAxis <= 1)? "X" : (var.probeAxis <= 3)? "Y" : "Z" }
 
@@ -88,7 +96,7 @@ var sAxis = { (var.probeAxis <= 1)? "X" : (var.probeAxis <= 3)? "Y" : "Z" }
 set global.mosWPSfcAxis[var.workOffset] = { var.sAxis }
 
 ; Set surface position on relevant axis
-set global.mosWPSfcPos[var.workOffset] = { (var.probeAxis <= 1)? global.mosMI[0] : (var.probeAxis <= 3)? global.mosMI[1] : global.mosMI[2] }
+set global.mosWPSfcPos[var.workOffset] = { (var.probeAxis <= 1)? global.mosMI[0][0][0] : (var.probeAxis <= 3)? global.mosMI[0][0][1] : global.mosMI[0][0][2] }
 
 ; Report probe results if requested
 if { !exists(param.R) || param.R != 0 }

--- a/macro/movement/G6513.g
+++ b/macro/movement/G6513.g
@@ -126,7 +126,7 @@ while { iterations < #param.P }
     var curSurface = { param.P[var.surfaceNo] }
 
     ; Create vector to store start points, probed points, approach angle and surface angle
-    set var.pSfc[var.surfaceNo] = { vector(#var.curSurface, {{null, null, null}, {null, null, null}}), 0, null}
+    set var.pSfc[var.surfaceNo] = { vector(#var.curSurface, {{null, null, null}, {null, null, null}}), 0, null }
 
     var lastPos = { null }
 

--- a/macro/movement/G6513.g
+++ b/macro/movement/G6513.g
@@ -166,7 +166,7 @@ while { iterations < #param.P }
         var probedPos = { global.mosMI }
 
         ; Calculate the approach angle in radians based on the start and probed position
-        var rApproachCur = { atan2(var.probedPos[0] - var.startPos[0], var.probedPos[1] - var.startPos[1]) }
+        var rApproachCur = { atan2(var.probedPos[1] - var.startPos[1], var.probedPos[0] - var.startPos[0]) }
 
         ; Accumulate the approach angle
         set var.pSfc[var.surfaceNo][1] = { var.pSfc[var.surfaceNo][1] + (var.rApproachCur / #var.curSurface) }
@@ -182,7 +182,7 @@ while { iterations < #param.P }
         ; Calculate a surface angle from the probe point once we have two points
         if { var.lastPos != null }
             ; Calculate the surface angle from the raw points
-            set var.pSfc[var.surfaceNo][2] = { atan2(var.probedPos[0] - var.lastPos[0], var.probedPos[1] - var.lastPos[1]) }
+            set var.pSfc[var.surfaceNo][2] = { atan2(var.probedPos[1] - var.lastPos[1], var.probedPos[0] - var.lastPos[0]) }
 
         ; Move back to starting position before moving to next probe point
         G6550 I{ param.I } X{ var.startPos[0] } Y{ var.startPos[1] }
@@ -264,8 +264,8 @@ while { iterations < #var.pSfc }
     while { iterations < #var.surfacePoints }
         ; Do not overwrite the original vector otherwise
         ; we will lose the Z value in index 2
-        set var.pSfc[var.surfaceNo][0][iterations][0] = { var.surfacePoints[iterations][0] + var.dX }
-        set var.pSfc[var.surfaceNo][0][iterations][1] = { var.surfacePoints[iterations][1] + var.dY }
+        set var.pSfc[var.surfaceNo][0][iterations][0] = { var.surfacePoints[iterations][0] - var.dX }
+        set var.pSfc[var.surfaceNo][0][iterations][1] = { var.surfacePoints[iterations][1] - var.dY }
 
 ; Save the output surfaces
 set global.mosMI = { var.pSfc }

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -25,7 +25,7 @@ if { !exists(param.J) || !exists(param.K) || !exists(param.L) }
 if { !exists(param.P) }
     abort { "Must provide a probe depth below the top surface using the P parameter!" }
 
-if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) }
+if { (!exists(param.Q) || param.Q == 0) && (!exists(param.H) || !exists(param.I)) }
     abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
 
 if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCornerNames) }

--- a/macro/movement/G8000.g
+++ b/macro/movement/G8000.g
@@ -653,6 +653,7 @@ if { var.wizFeatureTouchProbe && (var.wizTouchProbeID == null || var.wizTouchPro
         M291 P{"Measured block dimensions are <b>X=" ^ global.mosWPDims[move.workplaceNumber][0] ^ " Y=" ^ global.mosWPDims[move.workplaceNumber][1] ^ "</b>.<br/>Current probe location is over the center of the item."} R"MillenniumOS: Configuration Wizard" S2 T0
 
     var deflectionX = { (var.measuredX - global.mosWPDims[move.workplaceNumber][0])/2 }
+
     var deflectionY = { (var.measuredY - global.mosWPDims[move.workplaceNumber][1])/2 }
 
     ; Deflection values are stored separately per axis, as 3d touch probes almost


### PR DESCRIPTION
This should be a cleaner, more accurate implementation of approach-based deflection compensation than the existing (in v0.5) quadrant-based system.

Signed-off-by: Ben Agricola <ben+git@agrico.la>