### PR TITLE
Fix quick mode parameter validation

### DIFF
--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -16,7 +16,7 @@ if { !exists(param.J) || !exists(param.K) || !exists(param.L) }
 if { !exists(param.Z) }
     abort { "Must provide a probe position using the Z parameter!" }
 
-if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) }
+if { (!exists(param.Q) || param.Q == 0) && (!exists(param.H) || !exists(param.I)) }
     abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
 
 ; Maximum of 4 corners (0..3)

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -25,7 +25,7 @@ if { !exists(param.J) || !exists(param.K) || !exists(param.L) }
 if { !exists(param.P) }
     abort { "Must provide a probe depth below the top surface using the P parameter!" }
 
-if { (!exists(param.Q) || param.Q == 0) && !exists(param.H) || !exists(param.I) }
+if { (!exists(param.Q) || param.Q == 0) && (!exists(param.H) || !exists(param.I)) }
     abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
 
 if { !exists(param.N) || param.N < 0 || param.N >= (#global.mosCornerNames) }


### PR DESCRIPTION
Quick mode did not successfully ignore the H and I parameters due to missing brackets.