### PR TITLE
Add the MillenniumOS UI and plugin build system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,60 +13,33 @@ jobs:
       id-token: 'write'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build release asset
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Duet Web Control
+        uses: actions/checkout@v4
+        with:
+          repository: Duet3D/DuetWebControl
+          ref: v3.6.0-rc.3
+          path: dwc-build
+
+      - name: Build release assets
         run: |
-          dist/release.sh mos-release-${{ github.ref_name }}
+          # Build the MillenniumOS release with SD card files and UI plugin
+          dist/release.sh mos-release-${{ github.ref_name }} dwc-build
+
       - name: Create Release
-        id: create_release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: MillenniumOS ${{ github.ref_name }}
-          body: ${{ github.event.head_commit.message }}
           draft: true
-          prerelease: false
-      - name: Upload Release Zip
-        id: upload-mos-zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/mos-release-${{ github.ref_name }}.zip
-          asset_name: mos-release-${{ github.ref_name }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload F360 Post-processor
-        id: upload-f360-post
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/millennium-os.cps
-          asset_name: millennium-os-${{ github.ref_name }}-post-f360.cps
-          asset_content_type: application/octet-stream
-
-      - name: Upload FreeCAD Post-processor
-        id: upload-freecad-post
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/millennium_os_post.py
-          asset_name: millennium_os_${{ github.ref_name }}_post.py
-          asset_content_type: application/octet-stream
-
-      - name: Upload F360 Machine Definition
-        id: upload-f360-mch-std
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/milo-v1.5-std.mch
-          asset_name: milo-v1.5-std-${{ github.ref_name }}.mch
-          asset_content_type: application/octet-stream
+          generate_release_notes: true
+          files: |
+            dist/mos-release-${{ github.ref_name }}.zip
+            dist/MillenniumOS-${{ github.ref_name }}.zip
+            dist/millennium-os.cps
+            dist/millennium_os_post.py
+            dist/milo-v1.5-std.mch

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The information contained here is for advanced users who want to understand furt
 
 ### Notes
 
-- You _must_ be using RRF `v3.5.0-rc.3` or above. MOS uses many 'meta gcode' features that do not exist in earlier versions.
+- You _must_ be using RRF `v3.6.0-rc.3` or above. MOS uses many 'meta gcode' features that do not exist in earlier versions.
 - MOS includes its own `daemon.g` file to implement repetitive tasks, such as VSSC. If you want to implement your own repetitive tasks, you should create a `user-daemon.g` file in the `/sys` directory, which MillenniumOS will run during its' own daemon loop. Disabling the MOS daemon tasks will also disable any `user-daemon.g` tasks. Do not use any long-running loops inside `user-daemon.g` as this will interfere with MOS's own daemon behaviour.
 
 ### RRF Config
@@ -65,7 +65,7 @@ You would add line(s) similar to these to your RRF `config.g` file, above where 
 
 ; Configure the touch probe as Z-Probe 0 on pin "probe" - mainboard specific, DO NOT COPY AND PASTE!
 ; Type P5             = filtered digital
-; Dive Height H2      = back-off 2mm before repeat probing
+; Dive Height H5      = back-off 5mm before repeat probing
 ; Max Retries A10     = retry probe a maximum of 10 times
 ; Tolerance S0.01     = when tolerance is reached, stop probing
 ; Travel Speed T1200  = travel moves run at this speed to the start of the probing location

--- a/dist/release.sh
+++ b/dist/release.sh
@@ -1,34 +1,66 @@
 #!/usr/bin/env bash
 WD="${PWD}"
 TMP_DIR=$(mktemp -d -t mos-release-XXXXX)
-ZIP_NAME="${1:-mos-release}.zip"
+ZIP_NAME="${1:-mos-sd-release}.zip"
 ZIP_PATH="${WD}/dist/${ZIP_NAME}"
 SYNC_CMD="rsync -a --exclude=README.md"
 COMMIT_ID=$(git describe --tags --exclude "release-*" --always --dirty)
 
+DWC_REPO_PATH="${2:-${WD}/DuetWebControl}"
+
+if [[ ! -d "${DWC_REPO_PATH}" ]]; then
+    echo "Duet Web Control repository not found at ${DWC_REPO_PATH}"
+    exit 1
+fi
+
 echo "Building release ${ZIP_NAME} for ${COMMIT_ID}..."
 
 # Make stub folder-structure
-mkdir -p ${TMP_DIR}/{sys,macros,sys/mos,posts}
+mkdir -p ${TMP_DIR}/sd/{sys,macros,sys/mos}
+mkdir -p ${TMP_DIR}/posts
 
 # Copy files to correct location in temp dir
-${SYNC_CMD} sys/* ${TMP_DIR}/sys/
-${SYNC_CMD} macro/public/* ${TMP_DIR}/macros/MillenniumOS
-${SYNC_CMD} macro/private/* ${TMP_DIR}/sys/mos
-${SYNC_CMD} macro/machine/* ${TMP_DIR}/sys/
-${SYNC_CMD} macro/movement/* ${TMP_DIR}/sys/
-${SYNC_CMD} macro/tool-change/* ${TMP_DIR}/sys/
+${SYNC_CMD} sys/* ${TMP_DIR}/sd/sys/
+${SYNC_CMD} macro/public/* ${TMP_DIR}/sd/macros/MillenniumOS
+${SYNC_CMD} macro/private/* ${TMP_DIR}/sd/sys/mos
+${SYNC_CMD} macro/machine/* ${TMP_DIR}/sd/sys/
+${SYNC_CMD} macro/movement/* ${TMP_DIR}/sd/sys/
+${SYNC_CMD} macro/tool-change/* ${TMP_DIR}/sd/sys/
 ${SYNC_CMD} post-processors/**/* ${TMP_DIR}/posts/
+${SYNC_CMD} ui/* ${TMP_DIR}/
 
 find ${TMP_DIR}
 
 [[ -f "${ZIP_PATH}" ]] && rm "${ZIP_PATH}"
 
 cd "${TMP_DIR}"
-mv sys/daemon.g sys/daemon.install
+
+mv sd/sys/daemon.g sd/sys/daemon.install
 echo "Replacing %%MOS_VERSION%% with ${COMMIT_ID}..."
-sed -si -e "s/%%MOS_VERSION%%/${COMMIT_ID}/g" {sys/*.g,posts/*}
+sed -si -e "s/%%MOS_VERSION%%/${COMMIT_ID}/g" {plugin.json,sd/sys/*.g,posts/*}
+
+# Copy post processors to dist
 cp -v posts/* "${WD}/dist"
-zip -x 'README.md' -x 'posts/' -x 'posts/**' -r "${ZIP_PATH}" *
+
+# Build the DWC Plugin
+(
+    cd "${DWC_REPO_PATH}"
+
+    npm install
+    npm run build-plugin ${TMP_DIR}
+
+    # MillenniumOS plugin is created in the dist/ folder of the DWC repo
+    cp dist/MillenniumOS-${COMMIT_ID}.zip "${WD}/dist/"
+)
+
+# Extract the "dwc" folder from the plugin into the SD directory
+unzip -o "${WD}/dist/MillenniumOS-${COMMIT_ID}.zip" "dwc/*" -d "${TMP_DIR}/sd"
+
+# Create the standalone ZIP file
+(
+    cd "sd"
+    zip -x 'README.md' -r "${ZIP_PATH}" *
+)
+
 cd "${WD}"
 rm -rf "${TMP_DIR}"

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,5 @@
+# MillenniumOS UI
+
+A plugin for RRF's Duet Web Control that integrates with MillenniumOS macros for a superior machine control experience.
+
+The UI Plugin bundles MillenniumOS macros so these can be installed seamlessly.

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,0 +1,1 @@
+import "./src/index.ts";

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "MillenniumOS",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/ui/plugin.json
+++ b/ui/plugin.json
@@ -1,0 +1,12 @@
+{
+    "dwcWebpackChunk": "MillenniumOS",
+    "id": "MillenniumOS",
+    "name": "MillenniumOS",
+    "author": "Nine Mile",
+    "version": "%%MOS_VERSION%%",
+    "license": "GPL-3.0-or-later",
+    "homepage": "https://github.com/benagricola",
+    "dwcVersion": "auto-major",
+    "rrfVersion": "auto-major",
+    "dependencies": {}
+  }

--- a/ui/src/MillenniumOS.vue
+++ b/ui/src/MillenniumOS.vue
@@ -1,0 +1,56 @@
+<style scoped>
+    .v-data-table >>> .v-data-table__wrapper > table > tbody > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > tbody > tr > th,
+    .v-data-table >>> .v-data-table__wrapper > table > thead > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > thead > tr > th,
+    .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > th {
+        padding: 0 4px;
+    }
+
+    .v-card__title {
+        height: 70px;
+    }
+
+    .v-btn-toggle > .v-btn.v-btn {
+        opacity: 1 !important;
+    }
+
+</style>
+<template>
+    <div class="mos mb-3">
+        <!-- <v-row>
+            <v-col cols="12">
+                <mos-job-progress-panel class="mb-2" />
+            </v-col>
+        </v-row> -->
+
+        <v-row>
+            <v-col cols="8" class="pb-0">
+                <mos-probing-panel class="mb-2 fill-height" />
+            </v-col>
+            <v-col cols="4" class="pb-0">
+                <mos-workplace-origins-panel class="mb-2 fill-height" />
+            </v-col>
+        </v-row>
+        <v-row>
+            <!-- <v-col cols="12" lg="6" class="pb-0">
+                <mos-probe-results-panel class="mb-2" />
+            </v-col> -->
+        </v-row>
+	</div>
+</template>
+
+<script lang="ts">
+export default {
+    data: () => ({
+        // nothing
+    }),
+    computed: {
+        // nothing
+    },
+    methods: {
+        // nothing
+    },
+};
+</script>

--- a/ui/src/components/BaseComponent.vue
+++ b/ui/src/components/BaseComponent.vue
@@ -1,0 +1,62 @@
+
+<script lang="ts">
+    import { Axis, AxisLetter, Tool } from "@duet3d/objectmodel";
+
+    import { defineComponent } from 'vue'
+
+    import { workplaceAsGCode } from "../utils/display";
+
+    import store from "@/store";
+
+    export default defineComponent({
+        props: {},
+        computed: {
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+            visibleAxesByLetter(): { [key in AxisLetter]: Axis } {
+                return store.state.machine.model.move.axes.filter(axis => axis.visible).reduce((acc, axis) => {
+                    acc[axis.letter] = axis;
+                    return acc;
+                }, {} as { [key in AxisLetter]: Axis });
+            },
+            currentTool(): Tool | null {
+                const toolIndex = store.state.machine.model.state.currentTool;
+                return toolIndex < 0 ? null : store.state.machine.model.tools[toolIndex];
+            },
+            probeTool(): Tool | null {
+                const ptID = store.state.machine.model.global.get("mosPTID") ?? -1;
+                if (ptID < 0 || (ptID >= (store.state.machine.model.limits?.tools ?? 0))) {
+                    return null;
+                }
+                return store.state.machine.model.tools[ptID];
+            },
+            currentWorkplace: {
+                get(): number {
+                    return store.state.machine.model.move.workplaceNumber;
+                },
+                async set(value: number) {
+                    await this.sendCode(workplaceAsGCode(value));
+                }
+            },
+            absolutePosition(): { [key in AxisLetter]: number } {
+                const axes = this.visibleAxesByLetter;
+
+                return Object.keys(axes).reduce((acc, key) => {
+                    const axis: Axis = axes[key as AxisLetter];
+                    // const toolOffset = this.currentTool ? this.currentTool.offsets[axis.] ?? 0 : 0;
+                    const toolOffset = 0;
+                    acc[key as AxisLetter] = axis.workplaceOffsets[this.currentWorkplace] + (axis.userPosition ?? 0) + toolOffset;
+                    return acc;
+                }, {} as { [key in AxisLetter]: number });
+            },
+        },
+        data() {
+            return {}
+        },
+        methods: {
+            async sendCode(code: string): Promise<string> {
+                return await store.dispatch("machine/sendCode", code);
+            },
+        }
+    });
+</script>

--- a/ui/src/components/inputs/AxisInput.vue
+++ b/ui/src/components/inputs/AxisInput.vue
@@ -1,0 +1,105 @@
+<template>
+    <v-text-field
+        dense
+        v-model="coord"
+        :disabled="uiFrozen"
+        color="warning"
+        :loading="loading"
+        @change="setCoordinate"
+        type="number"
+        step="0.001"
+        hide-details
+        class="text-body-2 mt-0"
+    >
+        <template v-slot:append>
+            <v-tooltip top
+            open-on-click
+            :open-on-hover="false"
+            >
+                <template v-slot:activator="{ on, attrs }">
+                    <v-icon
+                        mt-8
+                        small
+                        v-visible="hasError"
+                        v-bind="attrs"
+                        v-on="on"
+                        color="error"
+                        class="mt-1"
+                        >mdi-alert-box</v-icon>
+                </template>
+                <span>{{ errorMsg }}</span>
+            </v-tooltip>
+        </template>
+    </v-text-field>
+</template>
+<script lang="ts">
+    import Vue from "vue";
+    import BaseComponent from "../BaseComponent.vue";
+    import { Axis } from "@duet3d/objectmodel";
+
+    import store from "@/store";
+
+    Vue.directive('visible', function(el, binding) {
+        el.style.visibility = !!binding.value ? 'visible' : 'hidden';
+        el.style.opacity = !!binding.value ? '1' : '0';
+        el.style.cssText += 'transition: visibility 0.3s linear, opacity 0.3s linear;'
+    });
+
+
+    import { defineComponent } from 'vue';
+
+    export default defineComponent({
+        extends: BaseComponent,
+        props: {
+            axis: {
+                type: Axis,
+                required: true,
+            },
+            workplaceOffset: {
+                type: Number,
+                required: true,
+            }
+        },
+        computed: {
+		    uiFrozen(): Boolean { return store.getters["uiFrozen"]; },
+            hasError(): Boolean { return this.errorMsg !== ""; },
+            coord: {
+                get(): string {
+                    return this.axis.workplaceOffsets[this.workplaceOffset].toFixed(3);
+                },
+                set(value: string) {
+                    const num = parseFloat(value);
+                    if (isNaN(num)) {
+                        this.errorMsg = "Invalid number";
+                        return;
+                    }
+
+                    if (num < this.axis.min || num > this.axis.max) {
+                        this.errorMsg =  `Value must be between ${this.axis.min} and ${this.axis.max}`;
+                        return;
+                    }
+
+                    this.errorMsg = "";
+                    this.pendingValue = num;
+                }
+            }
+        },
+        data() {
+            return {
+                loading: false,
+                errorMsg: "",
+                pendingValue: 0,
+            }
+        },
+        methods: {
+            setCoordinate: async function () {
+                if(this.hasError || this.pendingValue === this.axis.workplaceOffsets[this.workplaceOffset]) {
+                    return;
+                }
+                this.loading = true;
+                await this.sendCode(`G10 L2 P${this.workplaceOffset+1} ${this.axis.letter}${this.pendingValue}`);
+                this.loading = false;
+            },
+        }
+    });
+</script>

--- a/ui/src/components/inputs/index.ts
+++ b/ui/src/components/inputs/index.ts
@@ -1,0 +1,5 @@
+import Vue from "vue";
+
+import AxisInput from "./AxisInput.vue";
+
+Vue.component("mos-axis-input", AxisInput);

--- a/ui/src/components/overrides/index.ts
+++ b/ui/src/components/overrides/index.ts
@@ -1,0 +1,2 @@
+import './panels';
+import './routes';

--- a/ui/src/components/overrides/panels/CNCContainerPanel.vue
+++ b/ui/src/components/overrides/panels/CNCContainerPanel.vue
@@ -1,0 +1,303 @@
+<template>
+	<div>
+		<v-row align="stretch" dense>
+			<v-col cols="3" lg="4" md="5" order="1" order-lg="1" sm="5">
+				<v-card class="justify-center fill-height">
+					<v-card-title class="py-2 font-weight-bold">
+						{{ $t("panel.status.caption") }}
+						<v-spacer></v-spacer>
+						<status-label v-if="status"></status-label>
+					</v-card-title>
+					<v-card-text>
+						<template v-if="visibleAxes">
+							<v-simple-table>
+								<template v-slot:default>
+									<tbody>
+										<tr>
+											<td><strong>{{ $t("plugins.millenniumos.panels.workplaceOrigins.workplaceHeader") }}</strong></td>
+											<td align="right">
+												<v-tooltip top>
+													<template v-slot:activator="{ on, attrs }">
+														<v-chip v-on="on" label outlined>
+															{{ $workplaceAsGCode(currentWorkplace) }}
+															<v-avatar right rounded :color="currentWorkplaceColor()">{{ currentWorkplace+1 }}</v-avatar>
+														</v-chip>
+													</template>
+													<span>{{  currentWorkplaceText() }}</span>
+												</v-tooltip>
+											</td>
+										</tr>
+										<tr v-if="toolNumber !== null && toolName !== null">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.toolName") }}</strong></td>
+											<td align="right">
+												<v-tooltip top>
+													<template v-slot:activator="{ on, attrs }">
+														<v-chip v-on="on" label outlined>
+															{{ toolNameShort() }}
+															<v-avatar right rounded class="green">{{ toolNumber }}</v-avatar>
+														</v-chip>
+													</template>
+													<span>{{ toolName }}</span>
+												</v-tooltip>
+											</td>
+										</tr>
+										<tr v-if="toolRadius !== null">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.toolRadius") }}</strong></td>
+											<td align="right">
+												<v-chip label outlined>
+													{{ $display(toolRadius, 3, "mm") }}
+													<v-avatar right rounded color="primary"><v-icon small>mdi-radius-outline</v-icon></v-avatar>
+												</v-chip>
+											</td>
+										</tr>
+										<tr v-if="toolOffset !== null">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.toolOffset") }}</strong></td>
+											<td align="right">
+												<v-chip label outlined>
+													{{ $display(toolOffset, 3, "mm") }}
+													<v-avatar right rounded color="primary"><v-icon small>mdi-arrow-expand-vertical</v-icon></v-avatar>
+												</v-chip>
+											</td>
+										</tr>
+										<tr v-if="touchProbe !== null">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.touchProbe") }}</strong></td>
+											<td align="right">
+												<v-chip label outlined >
+													{{ (!touchProbeEnabled)? $t('plugins.millenniumos.panels.cncStatus.probeDisabled') : probeText(touchProbe) }}
+													<v-avatar right rounded :color="(!touchProbeEnabled)? 'grey' : probeColor(touchProbe)">
+														<v-icon small>{{ probeIcon(touchProbe) }}</v-icon>
+													</v-avatar>
+												</v-chip>
+											</td>
+										</tr>
+										<tr v-if="toolsetter !== null">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.toolsetter") }}</strong></td>
+											<td align="right">
+												<v-chip label outlined >
+													{{ (!toolsetterEnabled)? $t('plugins.millenniumos.panels.cncStatus.probeDisabled') : probeText(toolsetter) }}
+													<v-avatar right rounded :color="(!toolsetterEnabled)? 'grey' : probeColor(toolsetter)">
+														<v-icon small>{{ probeIcon(toolsetter) }}</v-icon>
+													</v-avatar>
+												</v-chip>
+											</td>
+										</tr>
+										<tr v-if="rotationCompensation !== 0">
+											<td><strong>{{ $t("plugins.millenniumos.panels.cncStatus.rotationCompensation") }}</strong></td>
+											<td align="right">
+												<v-chip label outlined>
+													{{ $display(rotationCompensation, 3, "°") }}
+													<v-avatar right rounded color="primary"><v-icon small>mdi-restore</v-icon></v-avatar>
+												</v-chip>
+											</td>
+										</tr>
+									</tbody>
+								</template>
+							</v-simple-table>
+						</template>
+					</v-card-text>
+				</v-card>
+			</v-col>
+			<v-col cols="12" lg="8" md="7" order="4" order-md="2" sm="8">
+				<v-row align="stretch" class="fill-height">
+					<v-col cols="12" lg="12">
+						<mos-cnc-axes-position machinePosition class="fill-height" />
+					</v-col>
+					<v-col cols="12" lg="12">
+						<mos-spindle-control-panel class="fill-height" />
+					</v-col>
+				</v-row>
+			</v-col>
+			<!--<v-col cols="5" lg="3" md="3" order="2" order-lg="3" sm="4">
+				<v-card class="fill-height">
+					<v-card-title class="py-2 font-weight-bold">
+						{{ $t("panel.status.requestedSpeed") }}
+					</v-card-title>
+					<v-card-text>
+						{{ $displayMoveSpeed(currentMove.requestedSpeed) }}
+					</v-card-text>
+				</v-card>
+			</v-col>
+			<v-col cols="4" lg="3" md="3" order="2" order-lg="4" sm="4">
+				<v-card class="fill-height" order="5">
+					<v-card-title class="py-2 font-weight-bold">
+						{{ $t("panel.status.topSpeed") }}
+					</v-card-title>
+					<v-card-text>
+						{{ $displayMoveSpeed(currentMove.topSpeed) }}
+					</v-card-text>
+				</v-card>
+			</v-col>-->
+		</v-row>
+	</div>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../../BaseComponent.vue";
+
+import { ProbeType, AnalogSensorType, Board, CurrentMove, Probe, AnalogSensor, Axis } from "@duet3d/objectmodel";
+
+const enum WorkplaceSet {
+	NONE,
+	SOME,
+	ALL
+};
+
+import store from "@/store";
+
+import { isPrinting } from "@/utils/enums";
+import { workplaceAsGCode } from "../../../utils/display";
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    extends: BaseComponent,
+
+	computed: {
+		uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		status(): string { return store.state.machine.model.state.status; },
+		currentMove(): CurrentMove { return store.state.machine.model.move.currentMove; },
+		mainboard(): Board | undefined { return store.state.machine.model.boards.find(board => !board.canAddress); },
+		probesPresent() { return store.state.machine.model.sensors.probes.some((probe) => probe && probe.type !== ProbeType.none); },
+		probes(): Array<Probe | null> { return store.state.machine.model.sensors.probes; },
+		sensorsPresent(): boolean { return (this.mainboard && ((this.mainboard.vIn !== null) || (this.mainboard.v12 !== null) || (this.mainboard.mcuTemp !== null))) || this.probesPresent; },
+		analogSensors(): Array<AnalogSensor> {
+			return store.state.machine.model.sensors.analog.filter((sensor) => (sensor !== null) && sensor.name && (sensor.type !== AnalogSensorType.unknown)) as Array<AnalogSensor>;
+		},
+		visibleAxes(): Array<Axis> {
+			return store.state.machine.model.move.axes.filter(axis => axis.visible);
+		},
+		touchProbeEnabled(): boolean {
+			return (
+				store.state.machine.model.global.get('mosFeatTouchProbe') === true &&
+				store.state.machine.model.global.get('mosTPID') !== null
+			);
+		},
+		toolsetterEnabled(): boolean {
+			return (
+				store.state.machine.model.global.get('mosFeatToolSetter') === true &&
+				store.state.machine.model.global.get('mosTSID') !== null
+			);
+		},
+		touchProbe(): Probe | null {
+
+			const mosTPID: number = store.state.machine.model.global.get('mosTPID') ?? null;
+			if (mosTPID === null) {
+				return null;
+			}
+			const p = store.state.machine.model.sensors.probes.at(mosTPID);
+			return p ? p : null;
+		},
+		toolsetter(): Probe | null {
+			const mosTSID: number = store.state.machine.model.global.get('mosTSID') ?? null;
+			if (mosTSID === null) {
+				return null;
+			}
+			const p = store.state.machine.model.sensors.probes.at(mosTSID);
+			return p ? p : null;
+		},
+		toolNumber(): number | null {
+			const t = store.state.machine.model.state.currentTool ?? -1;
+			if ( t < 0 ) {
+				return null;
+			}
+			return t;
+		},
+		toolName(): string | null {
+			const t = store.state.machine.model.state.currentTool ?? -1;
+			if ( t < 0 ) {
+				return null;
+			}
+			return store.state.machine.model.tools.at(t)?.name ?? '';
+		},
+		toolRadius(): number | null {
+			const t = store.state.machine.model.state.currentTool ?? -1;
+			if ( t < 0 ) {
+				return null;
+			}
+			return store.state.machine.model.global.get('mosTT').at(t).at(0) ?? -1;
+		},
+		toolOffset(): number | null {
+			const t = store.state.machine.model.state.currentTool ?? -1;
+			if ( t < 0 ) {
+				return null;
+			}
+			// Return Z offset of tool (Axis 2)
+			return store.state.machine.model.tools.at(t)?.offsets[2] ?? -1;
+		},
+		rotationCompensation(): number {
+			return store.state.machine.model.move.rotation.angle;
+		},
+	},
+	methods: {
+		formatProbeValue(values: Array<number>) {
+			if (values.length === 1) {
+				return values[0];
+			}
+			return `${values[0]} (${values.slice(1).join(", ")})`;
+		},
+		probeSpanClasses(probe: Probe, index: number) {
+			let result: Array<string> = [];
+			if (index && store.state.machine.model.sensors.probes.length > 1) {
+				result.push("ml-2");
+			}
+			if (!isPrinting(store.state.machine.model.state.status) && probe.value.length > 0) {
+				if (probe.value[0] >= probe.threshold) {
+					result.push("red");
+					result.push(store.state.settings.darkTheme ? "darken-3" : "lighten-4");
+				} else if (probe.value[0] > probe.threshold * 0.9) {
+					result.push("orange");
+					result.push(store.state.settings.darkTheme ? "darken-2" : "lighten-4");
+				}
+			}
+			return result;
+		},
+		currentWorkplaceValid(): WorkplaceSet {
+			const offsets = this.visibleAxes.map(axis => axis.workplaceOffsets[this.currentWorkplace]);
+
+			if (offsets.every(offset => offset !== 0)) {
+				return WorkplaceSet.ALL;
+			}
+
+			return offsets.some(offset => offset !== 0) ? WorkplaceSet.SOME : WorkplaceSet.NONE;
+		},
+		currentWorkplaceColor(): string {
+			switch(this.currentWorkplaceValid()) {
+				case WorkplaceSet.ALL:
+					return 'success';
+				case WorkplaceSet.SOME:
+					return 'warning';
+				default:
+					return 'grey';
+			}
+		},
+		currentWorkplaceText(): string {
+			let translationString = "workplaceInvalid";
+			switch(this.currentWorkplaceValid()) {
+				case WorkplaceSet.ALL:
+					translationString = "workplaceValid";
+					break
+				case WorkplaceSet.SOME:
+					translationString = "workplacePartial";
+					break
+			}
+			return this.$t(`plugins.millenniumos.panels.cncStatus.${translationString}`, [workplaceAsGCode(this.currentWorkplace)]).toString();
+		},
+		probeColor(probe: Probe) {
+			return (probe.value[0] >= probe.threshold) ? 'red' : 'green';
+		},
+		probeText(probe: Probe) {
+			return this.$t((probe.value[0] >= probe.threshold) ? 'plugins.millenniumos.panels.cncStatus.probeTriggered' : 'plugins.millenniumos.panels.cncStatus.probeNotTriggered', [probe.value[0]]);
+		},
+		probeIcon(probe: Probe) {
+			return (probe.value[0] >= probe.threshold) ? 'mdi-bell-ring' : 'mdi-bell-sleep';
+		},
+		toolNameShort() {
+			const toolName = this.toolName;
+			if (toolName === null) {
+				return '';
+			}
+			return toolName.length > 20 ? toolName.substring(0, 20) + '...' : toolName;
+		},
+	}
+});
+</script>

--- a/ui/src/components/overrides/panels/CNCDashboardPanel.vue
+++ b/ui/src/components/overrides/panels/CNCDashboardPanel.vue
@@ -1,0 +1,51 @@
+<style scoped>
+.macro {
+    width: 100%;
+}
+</style>
+
+<template>
+    <v-row>
+        <v-col cols="12" class="pt-0 pb-0">
+            <cnc-movement-panel class="mb-2" />
+        </v-col>
+        <v-col cols="12" md="9">
+            <v-row dense>
+                <v-col cols="12">
+                    <spindle-speed-panel />
+                </v-col>
+                <v-col cols="12">
+                    <v-card>
+                        <v-card-text>
+                            <job-progress />
+                        </v-card-text>
+                    </v-card>
+                </v-col>
+                <v-col cols="4" class="flex-grow-1">
+                    <job-control-panel />
+                </v-col>
+                <v-col cols="4" class="flex-grow-1">
+                    <z-babystep-panel class="fill-height" />
+                </v-col>
+                <v-col cols="4" class="flex-grow-1">
+                    <speed-factor-panel class="fill-height" />
+                </v-col>
+            </v-row>
+        </v-col>
+        <v-col cols="12" md="3">
+            <v-row dense>
+                <macro-list class="macro" />
+            </v-row>
+        </v-col>
+    </v-row>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../../BaseComponent.vue";
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    extends: BaseComponent,
+});
+</script>

--- a/ui/src/components/overrides/panels/CNCMovementPanel.vue
+++ b/ui/src/components/overrides/panels/CNCMovementPanel.vue
@@ -1,0 +1,347 @@
+<style scoped>
+.move-btn {
+	padding-left: 0px !important;
+	padding-right: 0px !important;
+	min-width: 0;
+	height: 65px !important;
+}
+
+.wcs-selection {
+	max-width: 200px;
+}
+</style>
+
+<template>
+	<v-card>
+		<v-card-title class="pt-0">
+			<v-icon small class="mr-1">mdi-swap-horizontal</v-icon>
+			{{ $t("panel.movement.caption") }}
+			<v-spacer />
+			<v-select v-model="currentWorkplace" :items="workCoordinates" class="wcs-selection"
+					  hint="Work Coordinate System" @change="updateWorkplaceCoordinate" persistent-hint />
+		</v-card-title>
+		<v-card-text v-show="visibleAxes.length">
+			<v-row dense>
+				<v-col cols="6" order="1" md="2" order-md="1">
+					<code-btn block v-show="visibleAxes.length" color="primary" code="G28"
+							  :title="$t('button.home.titleAll')" class="ml-0 move-btn">
+						{{ $t("button.home.captionAll") }}
+					</code-btn>
+				</v-col>
+				<v-col cols="6" order="2" md="8" order-md="2">
+					<v-menu offset-y left :disabled="uiFrozen">
+						<template #activator="{ on }">
+							<v-btn v-show="visibleAxes.length" :color="isProtectedMovesEnabled ? 'primary' : 'warning'" block class="mx-0 move-btn"
+								   :disabled="uiFrozen" v-on="on">
+								{{ (isProtectedMovesEnabled) ? $t("plugins.millenniumos.panels.cncMovement.protectionState.enabled", [protectedMoveProbeID]) : $t("plugins.millenniumos.panels.cncMovement.protectionState.disabled") }}
+								<v-icon>mdi-menu-down</v-icon>
+							</v-btn>
+						</template>
+
+						<v-card>
+							<v-list>
+								<v-list-item v-if="protectedMoveProbes.length == 1">
+									<v-icon class="mr-1">mdi-alert-octagon-outline</v-icon>
+									{{ $t("plugins.millenniumos.panels.cncMovement.protectionProbeNone") }}
+								</v-list-item>
+								<template v-if="protectedMoveProbes.length > 1">
+									<v-list-item
+										v-for="probe in protectedMoveProbes"
+										:key="probe.id"
+										v-if="probe.id !== protectedMoveProbeID"
+										@click="protectedMoveProbeID = probe.id">
+										<v-icon class="mr-1">{{ probe.id === -1 ? 'mdi-alert-octagon-outline': 'mdi-target-variant' }}</v-icon>
+										{{ probe.description }}
+									</v-list-item>
+
+								</template>
+							</v-list>
+						</v-card>
+					</v-menu>
+				</v-col>
+				<v-col cols="12" order="3" md="2" order-md="3">
+					<v-btn @click="setWorkplaceZero" block class="move-btn">
+						{{ $t("panel.movement.setWorkXYZ") }}
+					</v-btn>
+				</v-col>
+			</v-row>
+
+			<v-row v-for="(axis, axisIndex) in visibleAxes" :key="axisIndex" dense>
+				<!-- Regular home buttons -->
+				<v-col cols="2" order="1" sm="4" md="1" order-md="1">
+					<v-row dense>
+						<v-col>
+							<code-btn tile block :color="axis.homed ? 'primary' : 'warning'" :disabled="uiFrozen"
+									  :title="$t('button.home.title', [/[a-z]/.test(axis.letter) ? `'${axis.letter}` : axis.letter])"
+									  :code="`G28 ${/[a-z]/.test(axis.letter) ? '\'' : ''}${axis.letter}`" class="move-btn">
+								{{ $t("button.home.caption", [axis.letter]) }}
+							</code-btn>
+						</v-col>
+					</v-row>
+				</v-col>
+
+				<!-- Decreasing movements -->
+				<v-col cols="6" order="3" md="5" order-md="2">
+					<v-row dense>
+						<v-col v-for="index in numMoveSteps" :key="index" :class="getMoveCellClass(index - 1)">
+							<v-btn @click="sendMoveCode(axis, index-1, true)" no-wait
+									  @contextmenu.prevent="showMoveStepDialog(axis.letter, index - 1)" block tile
+									  class="move-btn">
+								<v-icon>mdi-chevron-left</v-icon>
+								{{ axis.letter + showSign(-moveSteps(axis.letter)[index - 1]) }}
+							</v-btn>
+						</v-col>
+					</v-row>
+				</v-col>
+
+				<!-- Increasing movements -->
+				<v-col cols="6" order="4" md="5" order-md="3">
+					<v-row dense>
+						<v-col v-for="index in numMoveSteps" :key="index" :class="getMoveCellClass(numMoveSteps - index)">
+							<v-btn @click="sendMoveCode(axis, numMoveSteps - index, false)" no-wait
+									  @contextmenu.prevent="showMoveStepDialog(axis.letter, numMoveSteps - index)" block
+									  tile class="move-btn">
+								{{ axis.letter + showSign(moveSteps(axis.letter)[numMoveSteps - index]) }}
+								<v-icon>mdi-chevron-right</v-icon>
+							</v-btn>
+						</v-col>
+					</v-row>
+				</v-col>
+
+				<!-- Set axis-->
+				<v-col cols="2" order="2" offset="8" sm="4" offset-sm="4" md="1" order-md="4" offset-md="0">
+					<v-row dense>
+						<v-col>
+							<code-btn color="warning" tile block :code="`G10 L20 P${currentWorkplace} ${axis.letter}0`"
+									  class="move-btn">
+								{{ $t("panel.movement.set", [axis.letter]) }}
+							</code-btn>
+						</v-col>
+					</v-row>
+				</v-col>
+			</v-row>
+
+			<v-row dense>
+				<v-col>
+					<v-btn color="warning" @click="goToWorkplaceZero" tile block class="move-btn">
+						{{ $t("panel.movement.workzero") }}
+					</v-btn>
+				</v-col>
+			</v-row>
+		</v-card-text>
+
+		<v-alert :value="unhomedAxes.length !== 0" type="warning" class="mb-0">
+			{{ $tc("panel.movement.axesNotHomed", unhomedAxes.length) }}
+			<strong>
+				{{ unhomedAxes.map(axis => axis.letter).join(", ") }}
+			</strong>
+		</v-alert>
+		<v-alert :value="visibleAxes.length === 0" type="info">
+			{{ $t("panel.movement.noAxes") }}
+		</v-alert>
+
+		<input-dialog :shown.sync="moveStepDialog.shown" :title="$t('dialog.changeMoveStep.title')"
+					  :prompt="$t('dialog.changeMoveStep.prompt')" :preset="moveStepDialog.preset" is-numeric-value
+					  @confirmed="moveStepDialogConfirmed" />
+	</v-card>
+</template>
+
+<script lang="ts">
+import { Axis, AxisLetter, Probe } from "@duet3d/objectmodel";
+import Vue from "vue";
+
+import { MachineCache } from "../../../types/MachineCache"
+
+import { log, LogType } from "@/utils/logging";
+
+import store from "@/store";
+
+import { setPluginData, PluginDataType } from '@/store';
+
+import { ProbeType } from "@duet3d/objectmodel";
+
+type ProtectedMoveProbe = {
+	id: number;
+	description: string;
+};
+
+
+export default Vue.extend({
+	computed: {
+        pluginCache(): MachineCache { return store.state.machine.cache.plugins.MillenniumOS as MachineCache; },
+		uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		moveSteps(): (axisLetter: AxisLetter) => Array<number> { return ((axisLetter: AxisLetter) => store.getters["machine/settings/moveSteps"](axisLetter)); },
+		numMoveSteps(): number { return store.getters["machine/settings/numMoveSteps"]; },
+		visibleAxes(): Array<Axis> { return store.state.machine.model.move.axes.filter(axis => axis.visible); },
+		unhomedAxes(): Array<Axis> { return store.state.machine.model.move.axes.filter(axis => axis.visible && !axis.homed); },
+		workCoordinates(): Array<number> { return [...Array(9).keys()].map(i => i + 1); },
+		workplaceNumber(): number { return store.state.machine.model.move.workplaceNumber; },
+		protectedMoveProbeID: {
+			get(): number {
+			    if(this.currentProtectedMoveProbeID === -1) {
+                    const cachedProbeID = this.pluginCache.protectedMoveProbeID;
+                    if(store.state.machine.model.sensors.probes[cachedProbeID] !== null) {
+                        this.currentProtectedMoveProbeID = cachedProbeID;
+                    }
+                }
+				return this.currentProtectedMoveProbeID
+			},
+			set(value: number) {
+              this.currentProtectedMoveProbeID = value;
+              setPluginData('MillenniumOS', PluginDataType.machineCache, 'protectedMoveProbeID', value);
+			}
+		},
+		isProtectedMovesEnabled(): boolean { return this.protectedMoveProbeID >= 0; },
+		protectedMoveProbes: {
+			get(): Array<ProtectedMoveProbe> {
+				const probes: Array<ProtectedMoveProbe> = [];
+
+				// Enumerate probes
+				store.state.machine.model.sensors.probes.map((probe, index) => {
+					if (probe !== null && [ProbeType.digital, ProbeType.unfilteredDigital, ProbeType.blTouch].includes(probe.type)) {
+						probes.push({
+							id: index,
+							description: this.$t('plugins.millenniumos.panels.cncMovement.protectionProbeDescription', [index, ProbeType[probe.type], probe.travelSpeed, "mm/min"]).toString()
+						});
+					}
+				});
+				probes.push({
+					id: -1,
+					description: this.$t('plugins.millenniumos.panels.cncMovement.protectionProbeDisable', [store.state.machine.settings.moveFeedrate, "mm/min"]).toString()
+				});
+				return probes;
+			}
+		}
+
+	},
+	data() {
+		return {
+			moveStepDialog: {
+				shown: false,
+				axis: AxisLetter.X,
+				index: 0,
+				preset: 0
+			},
+			currentWorkplace: 0,
+			currentProtectedMoveProbeID: -1,
+		};
+	},
+	methods: {
+		getMoveStep(axis: Axis, index: number): number {
+			return this.moveSteps(axis.letter)[index];
+		},
+		getMoveCellClass(index: number) {
+			let classes = "";
+			if (index === 0 || index === 5) {
+				classes += "hidden-lg-and-down";
+			}
+			if (index > 1 && index < 4 && index % 2 === 1) {
+				classes += "hidden-md-and-down";
+			}
+			return classes;
+		},
+		getProtectedMoveCode(axis: Axis, position: number): string {
+			// G38.3 probe moves do not check axis limits, and they are always
+			// absolute moves. We need to check the limits ourselves, and calculate
+			// the absolute position of the target.
+
+			// Probe is always valid
+			const probe = store.state.machine.model.sensors.probes[this.protectedMoveProbeID] as Probe;
+
+			return `M120\nG90\nG53 G38.3 K${this.protectedMoveProbeID} F${probe.travelSpeed} ${/[a-z]/.test(axis.letter) ? '\'' : ""}${axis.letter}${position}\nM121`;
+
+		},
+		async sendMoveCode(axis: Axis, index: number, decrementing: boolean) {
+			let distance = this.getMoveStep(axis, index);
+			if(decrementing) {
+				distance = -distance;
+			}
+
+			const feedRate = store.state.machine.settings.moveFeedrate;
+
+			// Validate move target
+			const targetPos = (axis.machinePosition as number) + distance;
+
+			if(targetPos < axis.min || targetPos > axis.max) {
+            	log(LogType.error, "Move Error", `Target ${axis.letter}=${this.$display(targetPos, 1)} is out of bounds!`);
+				return;
+			}
+
+			if(!this.isProtectedMovesEnabled) {
+				return await this.sendCode(`M120\nG91\nG1 F${feedRate} ${/[a-z]/.test(axis.letter) ? '\'' : ""}${axis.letter}${distance}\nM121`);
+			}
+
+			// Validate probe configuration
+			const probe = store.state.machine.model.sensors.probes[this.protectedMoveProbeID] as Probe;
+
+			if(probe === null) {
+            	return log(LogType.error, "Protected Move Error", `Probe ${this.protectedMoveProbeID} is not configured!`);
+			}
+
+			// We allow the Z axis to move in a positive direction
+			// if the probe is triggered because there should be
+			// no obstructions above the probe.
+			if(axis.letter === AxisLetter.Z && !decrementing) {
+				return await this.sendCode(`M120\nG91\nG1 F${probe.travelSpeed} ${/[a-z]/.test(axis.letter) ? '\'' : ""}${axis.letter}${distance}\nM121`);
+			}
+
+			// Do not allow probe to move if already triggered.
+			if(probe.value[0] >= probe.threshold)  {
+				return log(LogType.error, "Protected Move Error", `Probe ${this.protectedMoveProbeID} is already triggered!`);
+			}
+
+			return await this.sendCode(this.getProtectedMoveCode(axis, targetPos));
+
+		},
+		showSign: (value: number) => (value > 0 ? `+${value}` : value),
+		showMoveStepDialog(axis: AxisLetter, index: number) {
+			this.moveStepDialog.axis = axis;
+			this.moveStepDialog.index = index;
+			this.moveStepDialog.preset = this.moveSteps(this.moveStepDialog.axis)[this.moveStepDialog.index];
+			this.moveStepDialog.shown = true;
+		},
+		moveStepDialogConfirmed(value: number) {
+			store.commit("machine/settings/setMoveStep", {
+				axis: this.moveStepDialog.axis,
+				index: this.moveStepDialog.index,
+				value
+			});
+		},
+		async sendCode(code: string) {
+			await store.dispatch("machine/sendCode", code);
+		},
+		async setWorkplaceZero() {
+			let code = `G10 L20 P${this.currentWorkplace}`;
+			this.visibleAxes.forEach(axis => (code += ` ${axis.letter}0`));
+			await store.dispatch("machine/sendCode", `${code}\nG10 L20 P${this.currentWorkplace}`);
+		},
+		async goToWorkplaceZero() {
+			await store.dispatch("machine/sendCode", 'M98 P"workzero.g"');
+		},
+		async updateWorkplaceCoordinate() {
+			let code;
+			if (this.currentWorkplace < 7) {
+				code = `G${53 + this.currentWorkplace}`;
+			} else {
+				code = `G59.${this.currentWorkplace - 6}`;
+			}
+
+			if (code) {
+				await store.dispatch("machine/sendCode", `${code}\nG10 L20 P${this.currentWorkplace}`);
+			}
+		},
+	},
+	mounted() {
+		this.currentWorkplace = this.workplaceNumber + 1;
+	},
+	watch: {
+		isConnected() {
+			// Hide dialogs when the connection is interrupted
+			this.moveStepDialog.shown = false;
+		},
+		workplaceNumber(to: number) {
+			this.currentWorkplace = to + 1;
+		}
+	},
+});
+</script>

--- a/ui/src/components/overrides/panels/index.ts
+++ b/ui/src/components/overrides/panels/index.ts
@@ -1,0 +1,12 @@
+import Vue from "vue";
+
+// Override default panels or components by importing
+// them here and then registering them with the same
+// name as the default component or panel.
+import CNCContainerPanel from "./CNCContainerPanel.vue";
+import CNCDashboardPanel from "./CNCDashboardPanel.vue";
+import CNCMovementPanel from "./CNCMovementPanel.vue";
+
+Vue.component("cnc-movement-panel", CNCMovementPanel);
+Vue.component("cnc-container-panel", CNCContainerPanel);
+Vue.component("cnc-dashboard-panel", CNCDashboardPanel);

--- a/ui/src/components/overrides/routes/Job/Status.vue
+++ b/ui/src/components/overrides/routes/Job/Status.vue
@@ -1,0 +1,66 @@
+<style scoped>
+.chart-height-limit {
+	max-height: 320px;
+}
+</style>
+
+<template>
+	<div class="d-flex flex-column">
+		<job-progress />
+
+		<v-row class="mt-0" :dense="$vuetify.breakpoint.mobile">
+			<v-col order="1" order-md="1" cols="12" sm="6" md="3" xl="2">
+				<v-row align="center" :dense="$vuetify.breakpoint.mobile">
+					<v-col cols="12">
+						<job-control-panel />
+					</v-col>
+					<v-col cols="12" class="d-none d-sm-block d-md-none">
+						<speed-factor-panel />
+					</v-col>
+				</v-row>
+			</v-col>
+
+			<v-col order="0" order-md="2" cols="12" md="5" xl="7" class="d-none d-sm-flex flex-column">
+				<mos-job-code-panel class="mb-5" />
+
+				<v-row class="flex-grow-0 flex-shrink-1 d-none d-md-flex">
+					<v-col cols="12">
+						<job-estimations-panel />
+					</v-col>
+					<v-col cols="12">
+						<job-data-panel />
+					</v-col>
+				</v-row>
+
+				<v-row class="flex-grow-0 flex-shrink-1 hidden-sm-and-up mt-3">
+					<v-col cols="6" md="6">
+						<speed-factor-panel />
+					</v-col>
+				</v-row>
+			</v-col>
+
+			<v-col order="2" order-md="3" cols="12" sm="6" md="4" xl="3">
+				<v-row :dense="$vuetify.breakpoint.mobile">
+					<v-col cols="12" class="hidden-md-and-up">
+						<job-data-panel />
+					</v-col>
+					<v-col cols="12" class="hidden-md-and-up">
+						<job-info-panel />
+					</v-col>
+
+					<v-col cols="12" class="hidden-sm-only">
+						<speed-factor-panel />
+					</v-col>
+				</v-row>
+			</v-col>
+		</v-row>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({});
+</script>

--- a/ui/src/components/overrides/routes/index.ts
+++ b/ui/src/components/overrides/routes/index.ts
@@ -1,0 +1,19 @@
+import Vue, { VueConstructor, ComponentPublicInstance, DefineComponent } from "vue";
+import { default as VueRouter } from "@/routes";
+import OriginalJobStatus from "@/routes/Job/Status.vue";
+import JobStatus from "./Job/Status.vue";
+
+// List of original => new components to override
+const overrides: [VueConstructor<Vue>, DefineComponent<any, any, any, any>][] = [
+    [OriginalJobStatus, JobStatus as DefineComponent<any, any, any, any>]
+];
+
+// Override routes with the new component.
+VueRouter.beforeEach((to, _, next) => {
+    overrides.forEach(([original, replacement]) => {
+        if (to.matched[0].components.default === original) {
+            to.matched[0].components.default = replacement;
+        }
+    });
+    next();
+});

--- a/ui/src/components/panels/CNCAxesPosition.vue
+++ b/ui/src/components/panels/CNCAxesPosition.vue
@@ -1,0 +1,139 @@
+<style scoped>
+.axis-span {
+	border-radius: 5px;
+}
+
+@media screen and (max-width: 600px) {
+	.large-font-height {
+		height: 35px;
+	}
+
+	.large-font {
+		font-size: 30px;
+	}
+}
+
+@media screen and (min-width: 601px) {
+	.large-font-height {
+		height: 55px;
+	}
+
+	.large-font {
+		font-size: 50px;
+	}
+}
+</style>
+
+<template>
+	<v-card class="py-0">
+		<v-card-title class="py-2">
+			<strong>
+				{{ $t("plugins.millenniumos.panels.axesPosition.positionHeader") }}
+			</strong>
+		</v-card-title>
+		<v-card-text class="pt-10">
+			<v-row align-content="center" no-gutters class="">
+				<v-col v-for="(axis, index) in visibleAxes" :key="axis.letter" class="d-flex flex-column align-center">
+					<v-tooltip top>
+						<template v-slot:activator="{ on, attrs }">
+							<span v-on="on" class="axis-span large-font large-font-height pt-4" :class="axisSpanClasses(index)">
+								{{ axis.letter }}
+							</span>
+						</template>
+						<span>{{ axisTooltipText(index) }}</span>
+					</v-tooltip>
+					<v-tooltip top>
+						<template v-slot:activator="{ on, attrs }">
+							<div v-on="on" class="large-font large-font-height pt-4">
+								{{ $displayAxisPosition(axis, false) }}
+							</div>
+						</template>
+						<span>{{ $t('panel.status.toolPosition') }}</span>
+					</v-tooltip>
+					<v-tooltip v-if="machinePosition" top>
+						<template v-slot:activator="{ on, attrs }">
+							<div v-on="on" class="lighten-2">
+								{{ $displayAxisPosition(axis, true) }}
+							</div>
+						</template>
+						<span>{{ $t('panel.status.machinePosition') }}</span>
+					</v-tooltip>
+				</v-col>
+			</v-row>
+		</v-card-text>
+	</v-card>
+</template>
+
+<script lang="ts">
+import { Axis } from "@duet3d/objectmodel";
+import BaseComponent from "../BaseComponent.vue";
+
+import store from "@/store";
+
+const enum AxisState {
+	NONE,
+	HOMED,
+	AT_STOP
+};
+
+import { defineComponent } from "vue";
+
+export default defineComponent({
+	extends: BaseComponent,
+	props: {
+		machinePosition: {
+			type: Boolean,
+			required: true
+		}
+	},
+	computed: {
+		darkTheme(): boolean {
+			return store.state.settings.darkTheme;
+		},
+		visibleAxes(): Array<Axis> {
+			return store.state.machine.model.move.axes.filter(axis => axis.visible);
+		}
+	},
+	methods: {
+		axisState(axisIndex: number) : AxisState {
+			const homed = store.state.machine.model.move.axes[axisIndex].homed;
+			const atEndstop = axisIndex < store.state.machine.model.sensors.endstops.length && store.state.machine.model.sensors.endstops[axisIndex]?.triggered;
+			return (homed ? (atEndstop) ? AxisState.AT_STOP : AxisState.HOMED : AxisState.NONE);
+		},
+		axisSpanClasses(axisIndex: number) {
+			const classList: Array<string> = ['large-font-height', 'px-2'];
+			classList.push(this.darkTheme ? "darken-3" : "lighten-4");
+			if(axisIndex < 0) {
+				return classList;
+			}
+
+			const state = this.axisState(axisIndex);
+
+			switch(this.axisState(axisIndex)) {
+				case AxisState.NONE:
+					classList.push("grey");
+					break;
+				case AxisState.AT_STOP:
+					classList.push("light-green");
+					break;
+			}
+			return classList;
+		},
+
+		axisTooltipText(axisIndex: number): string {
+			const axisLetter = this.visibleAxes[axisIndex].letter;
+			let translationString = "notHomed";
+			switch(this.axisState(axisIndex)) {
+				case AxisState.HOMED:
+					translationString = "homed";
+					break
+				case AxisState.AT_STOP:
+					translationString = "atStop";
+					break
+			}
+			return this.$t(`plugins.millenniumos.panels.axesPosition.${translationString}`, [axisLetter]).toString();
+		}
+	}
+});
+</script>
+

--- a/ui/src/components/panels/CNCAxesPosition.vue
+++ b/ui/src/components/panels/CNCAxesPosition.vue
@@ -109,7 +109,7 @@ export default defineComponent({
 
 			const state = this.axisState(axisIndex);
 
-			switch(this.axisState(axisIndex)) {
+			switch(state) {
 				case AxisState.NONE:
 					classList.push("grey");
 					break;

--- a/ui/src/components/panels/JobCodePanel.vue
+++ b/ui/src/components/panels/JobCodePanel.vue
@@ -1,0 +1,41 @@
+
+<template>
+	<v-card class="d-flex flex-column flex-grow-1">
+		<v-card-title>
+			<span>
+				<v-icon small class="mr-1">mdi-file-code</v-icon>
+        		{{ $t("plugins.millenniumos.panels.jobCode.cardTitle") }}
+			</span>
+		</v-card-title>
+
+		<v-card-text>
+			<code-stream>G0 X0 Y0 Z0</code-stream>
+		</v-card-text>
+	</v-card>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../BaseComponent.vue";
+
+import store from "@/store";
+
+import { defineComponent } from "vue";
+export default defineComponent({
+	extends: BaseComponent,
+	computed: {
+		code(): string { return "\nG0 X0 Y0 Z0\nG1 X10 Y10\nG1 X0"; },
+		darkTheme(): boolean { return store.state.settings.darkTheme; },
+		language(): string { return store.state.settings.language; },
+	},
+	data() {
+		return {
+			showAllLayers: false
+		}
+	},
+	methods: {},
+	mounted() {
+		const that = this;
+	},
+	watch: {}
+});
+</script>

--- a/ui/src/components/panels/JobCodePanel.vue
+++ b/ui/src/components/panels/JobCodePanel.vue
@@ -34,7 +34,6 @@ export default defineComponent({
 	},
 	methods: {},
 	mounted() {
-		const that = this;
 	},
 	watch: {}
 });

--- a/ui/src/components/panels/JobProgressPanel.vue
+++ b/ui/src/components/panels/JobProgressPanel.vue
@@ -1,0 +1,46 @@
+<template>
+    <v-card>
+        <v-card-text>
+            <v-container fluid>
+                <v-row>
+                    <v-col>
+                            <v-stepper>
+                                <v-stepper-header>
+                                <v-stepper-step v-for="(step, k) in steps" :key="k" :step="k">{{ step.title }}</v-stepper-step>
+                                </v-stepper-header>
+                            </v-stepper>
+                    </v-col>
+                </v-row>
+            </v-container>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../BaseComponent.vue";
+
+// Steps should be loaded from the store.
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    extends: BaseComponent,
+
+    data() {
+        return {
+            steps: [
+                { title: "Run Job", done: false },
+                { title: "Probe Origin in G54", done: false },
+                { title: "Insert 6mm 1-Flute Endmill", done: false },
+                { title: "Review", done: false },
+                { title: "Face top surface", done: false },
+            ],
+        };
+    },
+    computed: {
+    },
+    methods: {},
+    mounted() {},
+    watch: {},
+});
+
+</script>

--- a/ui/src/components/panels/ProbeMethodRender.vue
+++ b/ui/src/components/panels/ProbeMethodRender.vue
@@ -1,0 +1,77 @@
+
+/**
+ * 
+ * JSFiddle to render a 3D cube with the 4 sides colored blue and the other 2 sides dark.
+ let camera, scene, renderer, cube
+
+init()
+
+function init() {
+  camera = new THREE.PerspectiveCamera(
+    50,
+    window.innerWidth / window.innerHeight,
+    0.01,
+    10,
+  )
+  camera.position.z = 3
+  camera.position.x = -3
+  camera.position.y = 1.5
+  camera.rotation.z = -0.35
+  camera.rotation.y = -1
+  camera.rotation.x = -0.5
+
+  scene = new THREE.Scene({ background: new THREE.Color(0x1e1e1e) })
+
+  const piece = new THREE.BoxGeometry(2, 0.75, 2).toNonIndexed()
+  const material = new THREE.MeshBasicMaterial({
+    vertexColors: true,
+  })
+  const positionAttribute = piece.getAttribute("position")
+  const colors = []
+
+  const color = new THREE.Color()
+  //for (let i = 0; i <= 6; i += 6) {
+  for (let i = 0; i < positionAttribute.count; i += 6) {
+    if ([1, 2, 5, 6].includes(i / 6 + 1)) {
+      color.setHex(0x2196f3)
+    } else {
+      color.setHex(0x1e1e1e)
+    }
+
+    colors.push(color.r, color.g, color.b)
+    colors.push(color.r, color.g, color.b)
+    colors.push(color.r, color.g, color.b)
+
+    colors.push(color.r, color.g, color.b)
+    colors.push(color.r, color.g, color.b)
+    colors.push(color.r, color.g, color.b)
+  } // for
+
+  // define the new attribute
+  piece.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3))
+
+  cube = new THREE.Mesh(piece, material)
+  scene.add(cube)
+
+  var objectEdges = new THREE.LineSegments(
+    new THREE.EdgesGeometry(cube.geometry),
+    new THREE.LineBasicMaterial({ color: 0x787878, linewidth: 1 }),
+  )
+  cube.add(objectEdges)
+
+  renderer = new THREE.WebGLRenderer({
+    antialias: true,
+  })
+  renderer.setSize(window.innerWidth, window.innerHeight)
+  renderer.setAnimationLoop(animation)
+  document.body.appendChild(renderer.domElement)
+}
+
+function animation(time) {
+  // cube.rotation.x = time / 2000;
+  cube.rotation.y = time / 2000
+
+  renderer.render(scene, camera)
+}
+
+*/

--- a/ui/src/components/panels/ProbeResultsPanel.vue
+++ b/ui/src/components/panels/ProbeResultsPanel.vue
@@ -1,0 +1,112 @@
+<style scoped>
+.v-card .probeType {
+    min-height: 200px;
+}
+</style>
+<template>
+    <v-card>
+        <v-card-title>Probe Results</v-card-title>
+        <v-container fluid>
+            <v-row>
+                <v-col cols="12">
+                    <v-data-table
+                        disable-filtering
+                        disable-pagination
+                        disable-sort
+                        hide-default-footer
+                        show-select
+                        :headers="headers"
+                        :items="items"
+                    >
+
+                        <template v-for="(axis, index) in visibleAxes" v-slot:[`item.${axis.letter}`]="{ item }">
+                            <div :key="axis.letter">
+                                {{ item[axis.letter] }}<v-icon>mdi-arrow-right-bold</v-icon>
+                            </div>
+                        </template>
+
+                        <template v-slot:item.actions="{ item }">
+                            <v-btn
+                                icon
+                                :disabled="uiFrozen || !allAxesHomed"
+                            >
+                                <v-icon>mdi-cursor-default</v-icon>
+                            </v-btn>
+                        </template>
+
+                    </v-data-table>
+                </v-col>
+            </v-row>
+            <v-row>
+                <v-col cols="12" class="d-flex justify-center">
+                    <v-btn
+                        x-large
+                        color="primary"
+                    >Probe</v-btn>
+                </v-col>
+            </v-row>
+        </v-container>
+    </v-card>
+</template>
+<script lang="ts">
+    import BaseComponent from "../BaseComponent.vue";
+    import { Axis } from "@duet3d/objectmodel";
+
+    function randomInt(min: number, max: number): number {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    import store from "@/store";
+
+    import { defineComponent } from 'vue';
+
+    export default defineComponent({
+        extends: BaseComponent,
+
+        props: {},
+        computed: {
+            currentWorkplace(): number { return store.state.machine.model.move.workplaceNumber; },
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+            visibleAxes(): Array<Axis> {
+                return store.state.machine.model.move.axes.filter(axis => axis.visible);
+            }
+        },
+        data() {
+
+            // Headers has static items at the start and end, and
+            // dynamic items representing each axis in the middle.
+            let headers: any = [];
+
+           headers = headers.concat(store.state.machine.model.move.axes.map(axis => ({
+                text: axis.letter,
+                value: axis.letter,
+                align: 'center',
+            })));
+
+            headers.push({
+                text: 'Actions',
+                value: 'actions',
+                align: 'end',
+            });
+
+            let items: any = [];
+            const workplaces = store.state.machine.model.limits?.workplaces ?? 0;
+            for (let w = 0; w < workplaces; w++) {
+                let workplace: any = {
+                    'index': w
+                };
+                store.state.machine.model.move.axes.forEach(axis => {
+                    workplace[axis.letter] = randomInt(0, 100);
+                });
+                items.push(workplace);
+            }
+            return {
+                headers: headers,
+                items: items,
+            }
+        },
+        methods: {
+        }
+    });
+</script>

--- a/ui/src/components/panels/ProbeSelectorPanel.vue
+++ b/ui/src/components/panels/ProbeSelectorPanel.vue
@@ -1,0 +1,111 @@
+<style scoped>
+    .probeTypeFull .v-card {
+        min-height: 200px;
+    }
+</style>
+<template>
+        <v-container fluid :class="!mustExpandProbeDetails ? 'probeTypeFull' : 'probeTypeCollapsed'">
+            <v-row>
+                <v-col v-for="(probeType, k) in allProbeTypes" cols="12" lg="3" md="6" :key="k">
+                    <v-card
+                        :color="selectedProbeTypeId == k ? 'warning' : 'primary'"
+                        @click="!mustExpandProbeDetails && selectProbeType(k)"
+                        >
+                        <v-card-title>
+                            <v-icon large left>{{ probeType.icon }}</v-icon>
+                            <h3>{{ probeType.name }}</h3>
+                        </v-card-title>
+                        <template v-if="mustExpandProbeDetails">
+                            <v-card-actions>
+                                <v-btn
+                                    @click="selectProbeType(k)">
+                                Select <v-icon>mdi-forward</v-icon>
+                                </v-btn>
+                                <v-spacer></v-spacer>
+                                <v-btn
+                                    @click="toggleDetails(k)"
+                                >
+                                    Details <v-icon>{{ shouldShowDetails(k) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
+                                </v-btn>
+                            </v-card-actions>
+                            <v-expand-transition>
+                                <div v-show="shouldShowDetails(k)">
+                                    <v-divider></v-divider>
+                                    <v-card-text>{{ probeType.description }}</v-card-text>
+                                </div>
+                            </v-expand-transition>
+                        </template>
+                        <v-card-text v-else>
+                            {{ probeType.description }}
+                        </v-card-text>
+                    </v-card>
+
+                </v-col>
+            </v-row>
+        </v-container>
+</template>
+<script lang="ts">
+    import BaseComponent from "../BaseComponent.vue";
+
+    import { defineComponent, PropType } from 'vue';
+
+    import { ProbeTypes } from "../../types/Probe";
+
+    import store from "@/store";
+
+    interface Data {
+        selectedProbeId: number;
+        expandedTypeDetails: number[];
+    }
+
+    export default defineComponent({
+        extends: BaseComponent,
+
+        props: {
+            value: {
+                type: String,
+                required: false
+            },
+            probeTypes: {
+                type: Object as PropType<ProbeTypes>,
+                required: true
+            },
+        },
+        computed: {
+            selectedProbeTypeId(): Number { return this.selectedProbeId; },
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+            mustExpandProbeDetails(): boolean {
+                 return this.$vuetify.breakpoint.mdAndDown;
+            },
+            allProbeTypes(): ProbeTypes {
+                return this.$props.probeTypes;
+            }
+        },
+        data(): Data {
+            return {
+                selectedProbeId: -1,
+                expandedTypeDetails: [],
+            }
+        },
+        mounted() {
+            this.selectedProbeId = -1;
+        },
+        methods: {
+            toggleDetails(index: number): void {
+                if(!this.expandedTypeDetails.includes(index)) {
+                    this.expandedTypeDetails.push(index);
+                } else {
+                    this.expandedTypeDetails = this.expandedTypeDetails.filter(i => i !== index);
+                }
+            },
+            shouldShowDetails(index: number): boolean {
+                return this.expandedTypeDetails.includes(index);
+            },
+            selectProbeType(index: number) {
+                this.selectedProbeId = index;
+                this.$emit('change', index);
+            }
+        }
+    });
+</script>

--- a/ui/src/components/panels/ProbeSettingsPanel.vue
+++ b/ui/src/components/panels/ProbeSettingsPanel.vue
@@ -1,0 +1,221 @@
+<template>
+    <v-card>
+        <v-card-title>
+            <v-icon large left>{{ probeType.icon }}</v-icon>
+            <h3>{{ probeType.name }}</h3>
+        </v-card-title>
+        <v-container fluid>
+            <v-form ref="probeSettings">
+                <v-row>
+                    <v-col cols="12" md="6" v-for="(setting, name, index) in probeType.settings" :key="index">
+                        <v-row>
+                            <v-col :id="index">
+                                <v-subheader>{{ setting.label ?? 'Unknown' }}</v-subheader>
+                                <v-row v-if="isNumberSetting(setting)">
+                                    <v-col cols="8" md="10">
+                                        <v-slider
+                                            class="mt-4"
+                                            v-model="setting.value"
+                                            :min="setting.min"
+                                            :max="setting.max"
+                                            :step="setting.step"
+                                            :hint="setting.description"
+                                            :prepend-icon="setting.icon"
+                                            :disabled="!allowInput(name)"
+                                            @input="setting.value = $event"
+                                            thumb-label
+                                            persistent-hint
+                                        >
+                                        </v-slider>
+                                    </v-col>
+                                    <v-col cols="4" md="2">
+                                        <v-text-field
+                                            class="pt-0 mt-0"
+                                            v-model="setting.value"
+                                            :suffix = "setting.unit"
+                                            @input="setting.value = $event"
+                                        ></v-text-field>
+                                    </v-col>
+                                </v-row>
+                                <v-row v-else-if="isBooleanSetting(setting)">
+                                    <v-col cols="8" md="10">
+                                        <v-switch
+                                            v-model="setting.value"
+                                            @change="setting.value = $event"
+                                            :hint="setting.description"
+                                            :prepend-icon="setting.icon"
+                                            :disabled="!allowInput(name)"
+                                            persistent-hint
+                                            class="mt-0"
+                                        >
+                                        </v-switch>
+                                    </v-col>
+                                    <v-col cols="4" md="2" class="text-right">
+                                        <v-tooltip top>
+                                            <template v-slot:activator="{ on, attrs }">
+                                                <v-btn
+                                                    :color="setting.value ? 'primary' : 'secondary'"
+                                                    label
+                                                    v-on="on"
+                                                    small
+                                                    style="pointer-events: none"
+                                                >
+                                                    <v-icon
+                                                        v-on="on"
+                                                    >
+                                                        {{  setting.value ? 'mdi-check' : 'mdi-close' }}
+                                                    </v-icon>
+                                                </v-btn>
+                                            </template>
+                                            {{ setting.value ? $t("plugins.millenniumos.probeSettings.booleanEnabled") : $t("plugins.millenniumos.probeSettings.booleanDisabled") }}
+                                        </v-tooltip>
+                                    </v-col>
+                                </v-row>
+                                <v-row v-else-if="isEnumSetting(setting)">
+                                    <v-col cols="8" md="10">
+                                        <v-input
+                                            :prepend-icon="setting.icon"
+                                        >
+                                            <v-chip-group
+                                                    v-model="setting.value"
+                                                    mandatory
+                                                    column
+                                                    class="ml-4 px-0 py-0 mt-n3"
+                                                    >
+                                                <v-tooltip v-for="(option, i) in setting.options" :key="i" top>
+                                                    <template v-slot:activator="{ on, attrs }">
+                                                        <v-chip
+                                                            v-on="on"
+                                                            :key="i"
+                                                            :value="i"
+                                                            :color="getEnumColor(i, setting.value)"
+                                                            :disabled="!allowInput(name)"
+                                                            label
+                                                            small
+                                                            class="mt-2 mb-0 pl-0 pr-1"
+                                                            >
+                                                            <v-icon class="px-0">{{ getEnumIcon(option) }}</v-icon>
+                                                            {{ getEnumText(option) }}
+                                                        </v-chip>
+                                                    </template>
+                                                    <span>{{ getEnumText(option) }}</span>
+                                                </v-tooltip>
+                                            </v-chip-group>
+                                        </v-input>
+                                    </v-col>
+                                    <v-col cols="4" md="2" class="text-right">
+                                        <v-tooltip top>
+                                            <template v-slot:activator="{ on, attrs }">
+                                                <v-btn
+                                                    :color="getEnumColor(setting.value, setting.value)"
+                                                    label
+                                                    small
+                                                    v-on="on"
+                                                    style="pointer-events: none"
+                                                >
+                                                    <v-icon
+                                                        v-on="on"
+                                                    >
+                                                        {{ getEnumIcon(setting.options[setting.value]) }}
+                                                    </v-icon>
+                                                </v-btn>
+                                            </template>
+                                            {{ getEnumText(setting.options[setting.value]) }}
+                                        </v-tooltip>
+                                    </v-col>
+                                </v-row>
+                            </v-col>
+                        </v-row>
+                    </v-col>
+                </v-row>
+            </v-form>
+        </v-container>
+        <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn @click="updateProbeSettings()" color="primary">
+                Continue <v-icon>mdi-forward</v-icon>
+            </v-btn>
+        </v-card-actions>
+    </v-card>
+
+</template>
+<script lang="ts">
+    import { PropType } from "vue";
+
+    import BaseComponent from "../BaseComponent.vue";
+
+    import { Axis, AxisLetter } from "@duet3d/objectmodel";
+
+    import store from "@/store";
+
+    import { defineComponent } from 'vue'
+
+    import { ProbeType, OptionOrString, hasOptionIcon, ProbeCommand, ProbeSettingAll, isBooleanSetting, isEnumSetting, isNumberSetting } from "../../types/Probe";
+
+    const colors = ['pink','blue','teal','green','blue-grey','deep-orange','indigo', 'red','purple'];
+
+    export default defineComponent({
+        extends: BaseComponent,
+        props: {
+            value: {
+                type: Object as PropType<ProbeCommand>,
+                required: true
+            },
+            probeType: {
+                type: Object as PropType<ProbeType>,
+                required: true
+            },
+        },
+        computed: {
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+            visibleAxesByLetter(): { [key in AxisLetter]: Axis } {
+                return store.state.machine.model.move.axes.filter(axis => axis.visible).reduce((acc, axis) => {
+                    acc[axis.letter] = axis;
+                    return acc;
+                }, {} as { [key in AxisLetter]: Axis });
+            },
+        },
+        data() {
+            return {}
+        },
+        methods: {
+            allowInput( settingName: string | number ): boolean {
+                let curSetting = this.probeType.settings[settingName] as ProbeSettingAll;
+
+                // If setting has no condition or refers to itself, always allow input
+                if(!curSetting.condition || curSetting.condition === settingName) {
+                    return true;
+                }
+
+                let conditionSetting = this.probeType.settings[curSetting.condition];
+
+                // Otherwise, allow input if condition is met. Default to true if conditionValue is not defined
+                let conditionValue = (typeof curSetting.conditionValue == "undefined")? true : curSetting.conditionValue;
+                return conditionSetting.value === conditionValue;
+            },
+            isNumberSetting: isNumberSetting,
+            isBooleanSetting: isBooleanSetting,
+            isEnumSetting: isEnumSetting,
+            getEnumColor(key: number, current: number): string {
+                // Darken the colour if the current value is the same as the key
+                return colors[key % colors.length] + (key === current ? ' lighten-2' : '');
+            },
+            getEnumText(opt: OptionOrString): string {
+                if(hasOptionIcon(opt)) {
+                    return opt.label;
+                }
+                return opt;
+            },
+            getEnumIcon(opt: OptionOrString): string {
+                if(hasOptionIcon(opt)) {
+                    return opt.icon;
+                }
+                return 'mdi-border-radius';
+            },
+            updateProbeSettings() {
+                this.$emit('change');
+            },
+        }
+    });
+</script>

--- a/ui/src/components/panels/ProbingPanel.vue
+++ b/ui/src/components/panels/ProbingPanel.vue
@@ -1,0 +1,346 @@
+<style lang="css">
+.v-progress-linear.animate .v-progress-linear__determinate
+{
+    animation: move 5s linear infinite;
+}
+@keyframes move {
+    0% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: 100px 100px;
+    }
+}
+</style>
+<template>
+    <v-card>
+        <v-card-title>
+            <v-icon large class="mr-1">mdi-target-variant</v-icon>
+            Probing
+            <v-spacer />
+            <code-btn small :color="allAxesHomed ? 'primary' : 'warning'" code="G28"
+                    :title="$t('button.home.titleAll')">
+                {{ $t("button.home.captionAll") }}
+            </code-btn>
+        </v-card-title>
+        <v-card-text :class="{'px-0': $vuetify.breakpoint.mdAndDown}">
+            <v-container fluid>
+                <v-row>
+                    <v-col cols="12">
+                        <v-tabs v-model="tab">
+                            <v-tab :disabled="probeActive || probing">
+                                <v-icon left>mdi-swap-horizontal</v-icon>
+                                Activate Probe
+                            </v-tab>
+
+                            <v-tab :disabled="!probeActive || probing">
+                                <v-icon left>mdi-target-variant</v-icon>
+                                Select Cycle
+                            </v-tab>
+
+                            <v-tab :disabled="!probeActive || !hasProbeTypeSelected || probing">
+                                <v-icon left>mdi-cog</v-icon>
+                                Configure Settings
+                            </v-tab>
+                            <v-tab :disabled="!probeActive || !hasProbeTypeSelected || probing">
+                                <v-icon left>mdi-run-fast</v-icon>
+                                Move to Position
+                            </v-tab>
+                            <v-tab :disabled="!probeActive || !hasProbeTypeSelected || !hasProbeCommand || probing">
+                                <v-icon left>mdi-check</v-icon>
+                                Review and Run
+                            </v-tab>
+                            <v-tab :disabled="!probing || !probeActive || !hasProbeTypeSelected || !hasProbeCommand || !hasStatus">
+                                <v-icon left>mdi-state-machine</v-icon>
+                                Status
+                            </v-tab>
+
+                            <v-tab-item>
+
+                                <v-btn
+                                    class="mt-4 mx-4"
+                                    v-if="!probeActive"
+                                    @click="activateProbe"
+                                    color="success"
+                                    :loading="probing"
+                                    >Activate Probe <v-icon>mdi-swap-horizontal</v-icon>
+                                </v-btn>
+
+                            </v-tab-item>
+                            <v-tab-item>
+                                <mos-probe-selector-panel :probeTypes="probeTypes"
+                                    @change="selectProbeType"
+                                />
+                            </v-tab-item>
+
+
+                            <v-tab-item>
+                                <mos-probe-settings-panel
+                                    v-if="hasProbeCommand"
+                                    :probeType="probeType"
+                                    v-model="probeCommand"
+                                    @change="nextStep"
+                                />
+                            </v-tab-item>
+
+                            <v-tab-item>
+                                <v-card>
+                                    <v-card-title>Move to Position</v-card-title>
+                                    <v-card-text>
+                                        <cnc-movement-panel />
+                                    </v-card-text>
+                                    <v-card-actions>
+                                        <v-spacer></v-spacer>
+                                        <v-btn @click="nextStep" color="primary">
+                                            Continue <v-icon>mdi-forward</v-icon>
+                                        </v-btn>
+                                    </v-card-actions>
+                                </v-card>
+                            </v-tab-item>
+
+                            <v-tab-item v-if="hasProbeCommand">
+                                <v-card>
+                                    <v-card-title>Review</v-card-title>
+                                    <v-card-text>
+                                        <pre v-if="!probing">{{ getProbeCode() }}</pre>
+                                    </v-card-text>
+                                    <v-card-actions>
+                                        <v-spacer></v-spacer>
+                                        <v-btn
+                                            v-if="probeActive"
+                                            @click="runProbe"
+                                            color="primary"
+                                            :loading="probing"
+                                            >
+                                            Run Cycle <v-icon>mdi-arrow-collapse-all</v-icon>
+                                        </v-btn>
+                                    </v-card-actions>
+                                </v-card>
+                            </v-tab-item>
+                            <v-tab-item v-if="hasStatus">
+                                <v-progress-linear
+                                    v-if="probeRetryTotal > 1"
+                                    class="mt-4 animate"
+                                    color="warning"
+                                    rounded
+                                    v-model="probeRetryProgress"
+                                    height=25
+                                    style="pointer-events: none"
+                                    striped
+                                    stream
+                                    :buffer-value="probeRetryBuffer"
+                                    >
+                                    <strong>Sample {{ Math.min(probeRetryCurrent+1, probeRetryTotal) }} / {{ probeRetryTotal }}</strong>
+                                </v-progress-linear>
+                                <v-progress-linear
+                                    class="mt-4 animate"
+                                    color="primary"
+                                    rounded
+                                    v-model="probePointProgress"
+                                    height=25
+                                    style="pointer-events: none"
+                                    striped
+                                    stream
+                                    :buffer-value="probePointBuffer"
+                                    >
+                                    <strong>Point {{ Math.min(probePointCurrent+1, probePointTotal) }} / {{ probePointTotal }}</strong>
+                                </v-progress-linear>
+                                <v-progress-linear
+                                    class="mt-4 animate"
+                                    color="success"
+                                    rounded
+                                    v-model="probeSurfaceProgress"
+                                    height=25
+                                    style="pointer-events: none"
+                                    striped
+                                    stream
+                                    :buffer-value="probeSurfaceBuffer"
+                                    >
+                                    <strong>Surface {{ Math.min(probeSurfaceCurrent+1, probeSurfaceTotal) }} / {{ probeSurfaceTotal }}</strong>
+                                </v-progress-linear>
+                            </v-tab-item>
+                        </v-tabs>
+                    </v-col>
+                </v-row>
+            </v-container>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../BaseComponent.vue";
+import store from "@/store";
+
+import { AxisLetter, Tool } from "@duet3d/objectmodel";
+
+import { default as probeTypes, ProbeTypes, ProbeCommand, ProbeType, ProbeSettingsModifier, ProbeSettingModifier } from '../../types/Probe';
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    extends: BaseComponent,
+
+    data() {
+        return {
+            probeTypes: probeTypes as ProbeTypes,
+            probeType: null as ProbeType | null,
+            probeCommand: null as ProbeCommand | null,
+            probing: false,
+            aborting: false,
+            tab: 0,
+        };
+    },
+    computed: {
+		allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+        workCoordinates(): Array<number> { return [...Array(9).keys()].map(i => i + 1); },
+        probeActive(): boolean {
+            return (this.currentTool?.number ?? -1) === (store.state.machine.model.global.get("mosPTID") ?? -2)
+        },
+        hasStatus(): boolean {
+            return this.probePointTotal > 0 && this.probeSurfaceTotal > 0;
+        },
+        hasProbeTypeSelected(): boolean { return this.probeType !== null; },
+        hasProbeCommand(): boolean { return this.probeCommand !== null; },
+        probeRetryCurrent(): number {
+            return (store.state.machine.model.global.get("mosPRRS") ?? 0);
+        },
+        probePointCurrent(): number {
+            return (store.state.machine.model.global.get("mosPRPS") ?? 0);
+        },
+        probeSurfaceCurrent(): number {
+            return (store.state.machine.model.global.get("mosPRSS") ?? 0);
+        },
+        probeRetryBuffer(): number {
+            return Math.min((this.probeRetryCurrent + 1) / this.probeRetryTotal * 100, 100);
+        },
+        probePointBuffer(): number {
+            return Math.min((this.probePointCurrent + 1) / this.probePointTotal * 100, 100);
+        },
+        probeSurfaceBuffer(): number {
+            return Math.min((this.probeSurfaceCurrent + 1) / this.probeSurfaceTotal * 100, 100);
+        },
+        probeRetryTotal(): number {
+            return store.state.machine.model.global.get("mosPRRT") ?? 0;
+        },
+        probePointTotal(): number {
+            return store.state.machine.model.global.get("mosPRPT") ?? 0;
+        },
+        probeSurfaceTotal(): number {
+            return store.state.machine.model.global.get("mosPRST") ?? 0;
+        },
+        probeRetryProgress(): number {
+            return this.probeRetryCurrent / this.probeRetryTotal * 100;
+        },
+        probePointProgress(): number {
+            return this.probePointCurrent / this.probePointTotal * 100;
+        },
+        probeSurfaceProgress(): number {
+            return this.probeSurfaceCurrent / this.probeSurfaceTotal * 100;
+        },
+    },
+    methods: {
+        nextStep() {
+            this.tab++;
+        },
+        async updateWorkplaceCoordinate() {
+            let code;
+            if (this.currentWorkplace < 7) {
+                code = `G${53 + this.currentWorkplace}`;
+            } else {
+                code = `G59.${this.currentWorkplace - 6}`;
+            }
+
+            if (code) {
+                await store.dispatch("machine/sendCode", `${code}\nG10 L20 P${this.currentWorkplace}`);
+            }
+        },
+        selectProbeType(to: number) {
+            if (to !== -1) {
+                var probeType: ProbeType = this.probeTypes[to];
+                this.probeType = probeType;
+                this.probeCommand = new ProbeCommand(this.probeType.code, this.probeType.settings);
+                this.nextStep();
+            }
+        },
+        getProbeSummary(): string {
+            if (!this.probeCommand) {
+                return "";
+            }
+
+            return "";
+        },
+        getProbeCode(): string {
+            if (!this.probeCommand) {
+                return "";
+            }
+
+            // Get the GCode for the probe command based on the operator settings
+            var mods = {
+                [AxisLetter.Z]: {
+                    numberValue: store.state.machine.model.move.axes.find(axis => axis.letter === AxisLetter.Z)?.machinePosition ?? 999,
+                    sign: -1,
+                } as ProbeSettingModifier
+            } as ProbeSettingsModifier;
+
+            const gcode: string[] = [
+                this.probeCommand.toGCode(mods),
+                // Add starting position
+                `J${this.absolutePosition[AxisLetter.X]}`,
+                `K${this.absolutePosition[AxisLetter.Y]}`,
+                `L${this.absolutePosition[AxisLetter.Z]}`,
+                `R0`, // Do not report probing results
+            ];
+
+            return gcode.join(" ");
+        },
+        async activateProbe() {
+            this.probing = true;
+            const ptID = this.probeTool?.number ?? -1;
+            await store.dispatch("machine/sendCode", `T${ptID}`);
+            this.probing = false;
+            if(this.probeActive) {
+                this.nextStep();
+            }
+        },
+        async runProbe() {
+            this.probing = true;
+            await this.sendCode("M5012");
+            this.nextStep();
+            const reply = await this.sendCode(this.getProbeCode());
+
+            if(reply.length > 0) {
+                this.tab = (this.probeActive ? 1 : 0);
+                this.probing = false;
+            }
+
+            await this.sendCode("M5012");
+        },
+    },
+    mounted() {
+        if(this.probeActive) {
+            this.nextStep();
+        }
+    },
+    watch: {
+        probeActive(newVal: boolean, oldVal: boolean) {
+            if(newVal && this.tab === 0) {
+                this.nextStep();
+            }
+        },
+        currentTool(newTool: (Tool | null), oldTool: (Tool | null)) {
+            if(!this.probeActive) {
+                this.tab = 0;
+            } else if(this.tab === 0) {
+                this.nextStep();
+            }
+        },
+        hasStatus(newVal: boolean, oldVal: boolean) {
+            if(oldVal && !newVal) {
+                this.tab = (this.probeActive ? 1 : 0);
+                this.probing = false;
+            }
+        },
+    }
+});
+
+</script>

--- a/ui/src/components/panels/SafeMovementPanel.vue
+++ b/ui/src/components/panels/SafeMovementPanel.vue
@@ -1,0 +1,100 @@
+<style>
+/* .mos .move-control {
+  flex-direction: column;
+} */
+</style>
+<template>
+    <v-card>
+        <v-card-title class="pt-0">
+            <v-icon small class="mr-1">mdi-bike-fast</v-icon>
+            Safe Movement
+        </v-card-title>
+        <v-card-text>
+            <v-container fluid>
+                <v-row dense>
+                    <v-col cols="1">
+                    </v-col>
+                    <v-col>
+                        <v-row>
+                            <v-col>
+                                <v-btn-toggle
+                                v-model="nextAxis"
+                                borderless
+                                mandatory
+                                color="pink"
+                                dense
+                                >
+                                    <v-btn
+                                        v-for="(axis, index) in visibleAxes"
+                                        large
+                                    >
+                                        <v-icon>mdi-alpha-{{ axis.letter.toLowerCase() }}-circle-outline</v-icon>
+                                    </v-btn>
+                                </v-btn-toggle>
+                            </v-col>
+                            <v-col align="center">
+                                <v-btn x-large>
+                                    <v-icon>mdi-arrow-left-bold</v-icon>
+                                </v-btn>
+                                <v-btn x-large>
+                                    <v-icon>mdi-arrow-right-bold</v-icon>
+                                </v-btn>
+                            </v-col>
+                        </v-row>
+                    </v-col>
+                    <v-col cols="3">
+                        <v-slider
+
+                        v-model="feedRate"
+                        min="10"
+                        max="100"
+                        step="10"
+                        thumb-label="always"
+                        ticks
+                        vertical
+                        class="mx-4"
+                        prepend-icon="mdi-speedometer-slow"
+                        append-icon="mdi-speedometer"
+                        >
+                        <template v-slot:thumb-label>{{ feedRate }}%</template>
+                        </v-slider>
+
+                    </v-col>
+                </v-row>
+            </v-container>
+        </v-card-text>
+    </v-card>
+
+</template>
+<script lang="ts">
+    import BaseComponent from "../BaseComponent.vue";
+    import { Axis, AxisLetter, KinematicsName, MoveCompensationType } from "@duet3d/objectmodel";
+
+    import store from "@/store";
+
+    import { defineComponent } from 'vue';
+
+    export default defineComponent({
+        extends: BaseComponent,
+
+        computed: {
+            currentAxis(): string { return store.state.machine.model.move.axes[this.axis].letter; },
+            currentAxisColor(): String { return this.axisColours[this.axis]; },
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    visibleAxes(): Array<Axis> { return store.state.machine.model.move.axes.filter(axis => axis.visible); },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+        },
+        data() {
+            return {
+                feedRate: 100,
+                axis: 0,
+                axisColours: ["pink", "lime", "orange", "purple", "cyan", "brown", "teal", "amber"],
+            }
+        },
+        methods: {
+            nextAxis() {
+                this.axis = (this.axis + 1) % this.visibleAxes.length;
+            },
+        }
+    });
+</script>

--- a/ui/src/components/panels/SpindleControlPanel.vue
+++ b/ui/src/components/panels/SpindleControlPanel.vue
@@ -1,0 +1,53 @@
+<template>
+	<v-card class="justify-center fill-height">
+		<v-card-title class="py-2 font-weight-bold">
+			Spindles
+		</v-card-title>
+		<v-card-text>
+			<v-simple-table>
+				<template v-slot:default>
+					<tbody>
+						<tr v-for="(spindle, index) in configuredSpindles">
+							<td><strong>Spindle #{{ index+1 }}</strong></td>
+							<td align="right">
+								<v-chip label outlined>
+									{{ spindle.current }}RPM
+									<v-avatar right rounded class="green">
+										<v-icon small>{{ spindleIcon(spindle) }}</v-icon>
+									</v-avatar>
+								</v-chip>
+							</td>
+						</tr>
+					</tbody>
+				</template>
+			</v-simple-table>
+		</v-card-text>
+	</v-card>
+</template>
+
+<script lang="ts">
+import BaseComponent from "../BaseComponent.vue";
+
+import { Spindle } from "@duet3d/objectmodel";
+
+import store from "@/store";
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    extends: BaseComponent,
+
+	computed: {
+		uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		configuredSpindles(): Array<Spindle> {
+			return store.state.machine.model.spindles.filter((spindle: Spindle | null): spindle is Spindle => spindle !== null && spindle?.state != "unconfigured");
+		},
+	},
+	methods: {
+		spindleIcon(spindle: Spindle) {
+			if(spindle.current === null) return 'mdi-help';
+			return (spindle.current > 0) ? 'mdi-axis-z-rotate-clockwise' : (spindle.current < 0) ? 'mdi-axis-z-rotate-counterclockwise' : 'mdi-pause';
+		}
+	}
+});
+</script>

--- a/ui/src/components/panels/WorkplaceOriginsPanel.vue
+++ b/ui/src/components/panels/WorkplaceOriginsPanel.vue
@@ -1,0 +1,184 @@
+<style scoped>
+    .v-data-table >>> .v-data-table__wrapper > table > tbody > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > tbody > tr > th,
+    .v-data-table >>> .v-data-table__wrapper > table > thead > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > thead > tr > th,
+    .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > td,
+    .v-data-table >>> .v-data-table__wrapper > table > tfoot > tr > th {
+    padding: 0 8px;
+    }
+</style>
+<template>
+    <v-card>
+        <v-card-title>{{ $t("plugins.millenniumos.panels.workplaceOrigins.cardTitle") }}</v-card-title>
+        <v-container fluid>
+            <v-row>
+                <v-col>
+                    <v-data-table
+                        dense
+                        disable-filtering
+                        disable-pagination
+                        disable-sort
+                        hide-default-footer
+                        mobile-breakpoint="0"
+                        class="text-body-2 px-2"
+                        :headers="headers"
+                        :items="items"
+                        :item-class="workplaceItemClass"
+                        item-key="offset"
+                        @click:row="selectWorkplace"
+                    >
+                        <template v-for="(axis, index) in visibleAxes" v-slot:[`item.${axis.letter}`]="{ item }">
+                            <mos-axis-input
+                                :key="index+1"
+                                :axis="axis"
+                                :workplaceOffset="item.offset"
+                            ></mos-axis-input>
+                        </template>
+                        <template v-slot:item.active="{ item }">
+                            <v-tooltip top>
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-btn
+                                        icon
+                                        v-bind="attrs"
+                                        v-on="on"
+                                        :disabled="uiFrozen"
+                                        :loading="item.switching"
+                                    >
+                                        <v-icon
+                                            :color="item.offset == currentWorkplace ? 'success' : 'error'"
+                                            :disabled="uiFrozen"
+                                            @click.stop="switchWorkplace(item)"
+                                        >
+                                            {{ item.offset == currentWorkplace ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline' }}
+                                        </v-icon>
+                                    </v-btn>
+                                </template>
+                                <span>Activate workplace {{ item.workplace }}</span>
+                            </v-tooltip>
+                        </template>
+                        <template v-slot:item.actions="{ item }">
+                            <v-container fluid py-1 px-1>
+                                <v-row>
+                                    <v-col cols="12" lg="12">
+                                        <v-tooltip top>
+                                            <template v-slot:activator="{ on, attrs }">
+                                                <v-btn
+                                                    icon
+                                                    v-bind="attrs"
+                                                    v-on="on"
+                                                    :disabled="uiFrozen"
+                                                    :loading="item.clearing"
+                                                >
+                                                    <v-icon small @click="clearWorkplace(item)">mdi-cancel</v-icon>
+                                                </v-btn>
+                                            </template>
+                                            <span>{{ $t("plugins.millenniumos.panels.workplaceOrigins.resetAction", [item.workplace]) }}</span>
+                                        </v-tooltip>
+                                    </v-col>
+                                </v-row>
+                            </v-container>
+                        </template>
+                    </v-data-table>
+                </v-col>
+            </v-row>
+        </v-container>
+    </v-card>
+</template>
+<script lang="ts">
+    import BaseComponent from "../BaseComponent.vue";
+    import { Axis } from "@duet3d/objectmodel";
+
+    import store from "@/store";
+    import { workplaceAsGCode } from "../../utils/display";
+
+    import { defineComponent } from 'vue';
+
+    export default defineComponent({
+        extends: BaseComponent,
+        props: {},
+        computed: {
+		    uiFrozen(): boolean { return store.getters["uiFrozen"]; },
+		    allAxesHomed(): boolean { return store.state.machine.model.move.axes.every(axis => axis.visible && axis.homed)},
+            visibleAxes(): Array<Axis> {
+                return store.state.machine.model.move.axes.filter(axis => axis.visible);
+            },
+            visibleAxesLetters(): Array<string> {
+                return this.visibleAxes.map(axis => axis.letter);
+            },
+            axisHeaders(): Array<any> {
+                return this.visibleAxes.map(axis => ({
+                    text: axis.letter,
+                    value: axis.letter,
+                    align: 'center',
+                }));
+            },
+            headers(): Array<any> {
+                return this.headersPrepend.concat(this.axisHeaders, this.headersAppend);
+            },
+            items(): Array<any> {
+                const workplaces = store.state.machine.model.limits?.workplaces ?? 0;
+                return Array.from({ length: workplaces }, (_, w) => {
+                    const code = workplaceAsGCode(w);
+                    const workplace: any = {
+                        'workplace': `${w+1} (${code})`,
+                        'code': code,
+                        'loading': false,
+                        'offset': w,
+                    };
+                    store.state.machine.model.move.axes.forEach(axis => {
+                        workplace[axis.letter] = axis.workplaceOffsets[w];
+                    });
+                    return workplace;
+                });
+            }
+        },
+        data() {
+            return {
+                selectedWorkplace: -1,
+                headersPrepend: [{
+                    text: 'Workplace',
+                    value: 'workplace',
+                    align: 'start',
+                },{
+                    text: this.$t('plugins.millenniumos.panels.workplaceOrigins.activeHeader'),
+                    value: 'active',
+                    align: 'center',
+                }],
+                headersAppend: [{
+                    text: '',
+                    value: 'actions',
+                    align: 'end',
+                }],
+            }
+        },
+        methods: {
+            // Selected workplace should be lighter than current
+            // Active workplace should be green
+            // Active and selected workplace should be darker than
+            // active workplace.
+            workplaceItemClass(item: any) {
+                return (item.offset == this.selectedWorkplace) ? 'primary' : '';
+            },
+            selectWorkplace(item: any) {
+                if(this.selectedWorkplace === item.offset) {
+                    this.selectedWorkplace = -1;
+                } else {
+                    this.selectedWorkplace = item.offset;
+                }
+            },
+            async updateItem(item: any, stateName: string, code: string | null = null) {
+                this.$set(item, stateName, true);
+                await this.sendCode(code ?? item.code);
+                this.$set(item, stateName, false);
+            },
+            async switchWorkplace(item: any) {
+                this.updateItem(item, 'switching');
+            },
+            async clearWorkplace(item: any) {
+                const axisStrings = this.visibleAxesLetters.map(axis => axis + "0").join(" ");
+                this.updateItem(item, 'clearing', `G10 L2 P${item.offset+1} ${axisStrings}`);
+            }
+        }
+    });
+</script>

--- a/ui/src/components/panels/index.ts
+++ b/ui/src/components/panels/index.ts
@@ -1,0 +1,26 @@
+'use strict'
+
+import Vue from 'vue';
+
+import CNCAxesPosition from "./CNCAxesPosition.vue";
+import SpindleControlPanel from "./SpindleControlPanel.vue";
+import JobCodePanel from "./JobCodePanel.vue";
+
+// import JobProgressPanel from "./JobProgressPanel.vue";
+// import SafeMovementPanel from './SafeMovementPanel.vue';
+import ProbingPanel from './ProbingPanel.vue';
+import ProbeSettingsPanel from "./ProbeSettingsPanel.vue";
+import ProbeSelectorPanel from "./ProbeSelectorPanel.vue";
+import WorkplaceOriginsPanel from "./WorkplaceOriginsPanel.vue";
+import ProbeResultsPanel from "./ProbeResultsPanel.vue";
+
+Vue.component("mos-cnc-axes-position", CNCAxesPosition);
+// Vue.component("mos-job-progress-panel", JobProgressPanel);
+// Vue.component("mos-safe-movement-panel", SafeMovementPanel);
+Vue.component("mos-probing-panel", ProbingPanel);
+Vue.component("mos-probe-selector-panel", ProbeSelectorPanel);
+Vue.component("mos-probe-settings-panel", ProbeSettingsPanel);
+Vue.component("mos-workplace-origins-panel", WorkplaceOriginsPanel);
+Vue.component("mos-probe-results-panel", ProbeResultsPanel);
+Vue.component("mos-spindle-control-panel", SpindleControlPanel);
+Vue.component("mos-job-code-panel", JobCodePanel);

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1,0 +1,86 @@
+{
+  "language": "English",
+  "menuCaption": "MillenniumOS",
+  "probeTypes": {
+    "boss": {
+      "menuName": "Boss",
+      "fullName": "Boss Probe",
+      "description": "Probe a circular positive feature."
+    },
+    "bore": {
+      "menuName": "Bore",
+      "fullName": "Bore Probe",
+      "description": "Probe a circular negative feature."
+    },
+    "rectanglePocket": {
+      "menuName": "Rectangle Pocket",
+      "fullName": "Rectangle Pocket Probe",
+      "description": "Probe a rectangular negative feature."
+    },
+    "rectangleBlock": {
+      "menuName": "Rectangle Block",
+      "fullName": "Rectangle Block Probe",
+      "description": "Probe a rectangular positive feature."
+    },
+    "outsideCorner": {
+      "menuName": "Outside Corner",
+      "fullName": "Outside Corner Probe",
+      "description": "Probe an outside corner of a positive feature."
+    },
+    "viseCorner": {
+      "menuName": "Vise Corner",
+      "fullName": "Vise Corner Probe",
+      "description": "Probe the top and sides of an outside corner of a positive feature."
+    },
+    "singleSurface": {
+      "menuName": "Single Surface",
+      "fullName": "Single Surface Probe",
+      "description": "Probe a single surface of a feature."
+    }
+  },
+  "probeSettings": {
+    "booleanEnabled": "Enabled",
+    "booleanDisabled": "Disabled"
+  },
+  "panels": {
+    "axesPosition": {
+      "positionHeader": "Position",
+      "notHomed": "Axis {0} is not homed",
+      "homed": "Axis {0} is homed",
+      "atStop": "Axis {0} endstop is triggered"
+    },
+    "cncStatus": {
+      "touchProbe": "Touch Probe",
+      "toolsetter": "Toolsetter",
+      "toolRadius": "Tool Radius",
+      "toolOffset": "Tool Offset",
+      "toolName": "Tool",
+      "probeNotTriggered": "Not Triggered / {0}",
+      "probeTriggered": "Triggered / {0}",
+      "probeDisabled": "Disabled",
+      "rotationCompensation": "Rotation Comp.",
+      "workplaceValid": "Workplace {0} has a non-zero origin set on all axes",
+      "workplacePartial": "Workplace {0} has a non-zero origin set on some axes",
+      "workplaceInvalid": "Workplace {0} has no origins set"
+    },
+    "cncMovement": {
+      "protectionState": {
+        "enabled": "Protected Moves Enabled (Probe {0})",
+        "disabled": "Protected Moves Disabled"
+      },
+      "protectionProbeDescription": "Probe {0}: {1} ({2} {3})",
+      "protectionProbeDisable": "Disable Protected Moves ({0} {1})",
+      "protectionProbeNone": "No suitable probes are configured"
+    },
+    "workplaceOrigins": {
+      "cardTitle": "Workplace Origins",
+      "resetAction": "Reset workplace {0}",
+      "workplaceHeader": "Workplace",
+      "activeHeader": "Active",
+      "actionsHeader": ""
+    },
+    "jobCode": {
+      "cardTitle": "Job Code"
+    }
+  }
+}

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,0 +1,30 @@
+'use strict';
+
+import { registerRoute } from "@/routes";
+import { registerPluginLocalization } from "@/i18n";
+import { registerPluginData, PluginDataType } from '@/store';
+
+import './utils';
+
+import './components/inputs';
+import './components/panels';
+import './components/overrides';
+
+import Dash from './MillenniumOS.vue'
+
+import en from "./i18n/en.json";
+
+registerPluginLocalization("millenniumos", "en", en);
+
+// Register a route via Settings -> Object Model
+registerRoute(Dash, {
+	Control: {
+		MillenniumOS: {
+			icon: "mdi-toolbox",
+			caption: "plugins.millenniumos.menuCaption",
+			path: "/Plugins/MillenniumOS"
+		}
+	}
+});
+
+registerPluginData('MillenniumOS', PluginDataType.machineCache, 'protectedMoveProbeID', -1);

--- a/ui/src/plugin.json
+++ b/ui/src/plugin.json
@@ -1,0 +1,12 @@
+{
+    "dwcWebpackChunk": "MillenniumOS",
+    "id": "MillenniumOS",
+    "name": "MillenniumOS",
+    "author": "Nine Mile",
+    "version": "auto",
+    "license": "GPL-3.0-or-later",
+    "homepage": "https://github.com/benagricola",
+    "dwcVersion": "auto",
+    "dependencies": {},
+    "rrfVersion": "auto"
+  }

--- a/ui/src/types/MachineCache.ts
+++ b/ui/src/types/MachineCache.ts
@@ -1,0 +1,4 @@
+export type MachineCache = {
+    // Previously selected probe ID
+    protectedMoveProbeID: number;
+}

--- a/ui/src/types/Probe.ts
+++ b/ui/src/types/Probe.ts
@@ -1,0 +1,755 @@
+const DS_OVERTRAVEL = 'overtravel';
+const DS_SURFACE_CLEARANCE = 'surface-clearance';
+const DS_EDGE_CLEARANCE = 'edge-clearance';
+const DS_CORNER_CLEARANCE = 'corner-clearance';
+const DS_QUICK = 'quick';
+
+export const valueSettings = {
+
+    [DS_QUICK]: {
+        type: 'boolean',
+        label: 'Quick Mode',
+        description: 'If enabled, only a single probe point will be performed on each surface. Angle calculations will not be performed. Turn this off for more accurate probe results.',
+        parameter: 'Q',
+        icon: 'mdi-clock-fast',
+        value: true,
+    },
+    [DS_OVERTRAVEL]: {
+        type: 'number',
+        label: 'Overtravel',
+        description: 'The distance the probe will travel past the expected edge of the feature or workpiece, to account for inaccuracies in the starting position or feature dimensions.',
+        parameter: 'O',
+        icon: 'mdi-unfold-less-vertical',
+        value: 2,
+        min: 1,
+        max: 20,
+        step: 0.1,
+        unit: 'mm'
+    },
+    [DS_SURFACE_CLEARANCE]: {
+        type: 'number',
+        label: 'Surface Clearance',
+        description: 'The distance the probe will move inwards towards the expected surface of the feature or workpiece, to account for inaccuracies in the starting position or work holding.',
+        parameter: 'T',
+        icon: 'mdi-unfold-more-vertical',
+        value: 10,
+        min: 2,
+        max: 50,
+        step: 0.1,
+        unit: 'mm'
+    },
+    [DS_CORNER_CLEARANCE]: {
+        type: 'number',
+        label: 'Corner Clearance',
+        description: 'The distance the probe will move inwards from the expected corner of the feature or workpiece, to account for inaccuracies in the starting position or corner radiuses.',
+        parameter: 'C',
+        icon: 'mdi-unfold-more-horizontal',
+        value: 5,
+        min: 1,
+        max: 50,
+        step: 0.1,
+        unit: 'mm'
+    },
+    [DS_EDGE_CLEARANCE]: {
+        type: 'number',
+        label: 'Edge Clearance',
+        description: 'The distance the probe will move inwards from the expected edge of the feature or workpiece, to account for inaccuracies in the starting position.',
+        parameter: 'C',
+        icon: 'mdi-unfold-more-horizontal',
+        value: 5,
+        min: 1,
+        max: 50,
+        step: 0.1,
+        unit: 'mm',
+        condition: 'quick',
+        conditionValue: false,
+    }
+};
+
+// Not used as these need to be
+// arrays of strings.
+export enum cornerNames {
+    "Front Left",
+    "Front Right",
+    "Back Right",
+    "Back Left"
+}
+
+export enum surfaceNames {
+    "Left",
+    "Right",
+    "Front",
+    "Back",
+    "Top"
+}
+
+export type Option = {
+    icon: string;
+    label: string;
+}
+
+export type OptionOrString = string | Option;
+
+export function hasOptionIcon(option: OptionOrString): option is Option {
+    return (option as Option).icon !== undefined;
+}
+
+export type ProbeSetting = {
+    type: string;
+    label: string;
+    description: string;
+    parameter?: string;
+    icon?: string;
+    min?: number;
+    max?: number;
+    multiplier?: number;
+    step?: number;
+    unit?: string;
+    options?: OptionOrString[];
+    condition?: string;
+    conditionValue?: boolean;
+}
+
+export type ProbeSettingBoolean = ProbeSetting & {
+    type: 'boolean';
+    value: boolean;
+};
+
+export type ProbeSettingNumber = ProbeSetting & {
+    type: 'number';
+    value: number;
+};
+
+export type ProbeSettingEnum = ProbeSetting & {
+    type: 'enum';
+    value: number;
+};
+
+export type ProbeSettingAll = ProbeSettingBoolean | ProbeSettingNumber | ProbeSettingEnum;
+
+export type ProbeSettings = {
+    [key: string]: ProbeSettingAll;
+}
+
+// If a ProbeSettingModifier is provided to
+// ProbeCommand.toGCode(), the operator-provided
+// value will be used as a modifier on the value
+// provided in the modifier rather than the static
+// value in the setting.
+// This allows for things like 'depth' settings to
+// output an absolute co-ordinate based on the current
+// position, supplied as a modifier.
+export type ProbeSettingNumberModifier = {
+    numberValue: number;
+}
+
+export type ProbeSettingModifier = ProbeSettingNumberModifier;
+
+export function isNumberModifier(mod: ProbeSettingModifier): mod is ProbeSettingNumberModifier {
+    return mod.numberValue !== undefined;
+}
+
+export type ProbeSettingsModifier = {
+    [key: string]: ProbeSettingModifier;
+}
+
+export interface IProbeCommand {
+    command: number;
+    settings: ProbeSettings,
+    addSetting: (id: string, setting: ProbeSettingAll) => void;
+    addSettings: (settings: ProbeSettings) => void;
+    toGCode: (mods: ProbeSettingsModifier | null) => string;
+}
+
+export class ProbeCommand implements IProbeCommand {
+    command: number;
+    settings: ProbeSettings;
+
+    constructor(command: number, settings: ProbeSettings | null) {
+        this.command = command;
+        this.settings = (settings) ? settings : {};
+    }
+
+    addSetting(id: string, setting: ProbeSettingAll) {
+        this.settings[id] = setting;
+    }
+
+    addSettings(settings: ProbeSettings) {
+        this.settings = settings;
+    }
+
+    toGCode(mods: ProbeSettingsModifier | null): string {
+        const gcode: string[] = [`G${this.command.toString()}`];
+        for (const key in this.settings) {
+            const setting = this.settings[key];
+
+            // Dont include settings without a parameter
+            if (setting.parameter === undefined) {
+                continue;
+            }
+
+            // Dont include settings whose conditional setting does
+            // not match the conditionValue.
+            if (setting.condition && this.settings[setting.condition].value !== setting.conditionValue) {
+                continue;
+            }
+
+            const p = setting.parameter;
+            const v = setting.value;
+            const m = setting.multiplier ? setting.multiplier : 1;
+
+            if (isBooleanSetting(setting)) {
+                gcode.push(`${p}${v ? 1 : 0}`);
+            } else if (isNumberSetting(setting)) {
+                if (mods && p in mods && isNumberModifier(mods[p])) {
+                    gcode.push(`${p}${((v as number) * m) + mods[p].numberValue}`);
+                } else {
+                    gcode.push(`${p}${v}`);
+                }
+            } else if (isEnumSetting(setting)) {
+                gcode.push(`${p}${v}`);
+            }
+        }
+        return gcode.join(' ');
+    }
+}
+
+export function isBooleanSetting(setting: ProbeSetting): setting is ProbeSettingBoolean {
+    return setting.type === 'boolean';
+}
+
+export function isNumberSetting(setting: ProbeSetting): setting is ProbeSettingNumber {
+    return setting.type === 'number';
+}
+
+export function isEnumSetting(setting: ProbeSetting): setting is ProbeSettingEnum {
+    return setting.type === 'enum';
+}
+
+export type ProbeType = {
+    name: string;
+    icon: string;
+    description: string;
+    code: number;
+    settings: ProbeSettings;
+}
+
+export type ProbeTypes = {
+    [key:string]: ProbeType;
+}
+
+export default {
+    bore: <ProbeType> {
+        name: 'Bore',
+        icon: 'mdi-circle-outline',
+        description: 'Finds the center of a circular bore (negative feature) by probing its inner diameter.',
+        code: 6500.1,
+        // G6500.1 W{var.workOffset} H{var.boreDiameter} O{var.overTravel} J{global.mosMI[0]} K{global.mosMI[1]} L{global.mosMI[2] - var.probingDepth}
+        settings: {
+            'diameter': {
+                type: 'number',
+                label: 'Diameter',
+                description: 'The approximate diameter of the bore.',
+                parameter: 'H',
+                icon: 'mdi-diameter-variant',
+                value: 10,
+                min: 1,
+                max: 100,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    boss: <ProbeType> {
+        name: 'Boss',
+        icon: 'mdi-circle',
+        description: 'Finds the center of a circular boss (positive feature or workpiece) by probing its outer diameter.',
+        code: 6501.1,
+        settings: {
+            'diameter': {
+                type: 'number',
+                label: 'Diameter',
+                description: 'The approximate diameter of the boss.',
+                parameter: 'H',
+                icon: 'mdi-diameter-variant',
+                value: 10,
+                min: 1,
+                max: 100,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    rectanglePocket: <ProbeType> {
+        name: 'Rectangle Pocket',
+        icon: 'mdi-rectangle-outline',
+        description: 'Finds the center of a rectangular pocket (negative feature) by probing its inner surfaces.',
+        code: 6502.1,
+        settings: {
+            'width': {
+                type: 'number',
+                label: 'Width (on X axis)',
+                description: 'The approximate width of the pocket (measured parallel to the X axis).',
+                parameter: 'H',
+                icon: 'mdi-unfold-more-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'length': {
+                type: 'number',
+                label: 'Length (on Y axis)',
+                description: 'The approximate length of the pocket (measured parallel to the Y axis).',
+                parameter: 'I',
+                icon: 'mdi-unfold-more-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_CORNER_CLEARANCE]: valueSettings[DS_CORNER_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    rectangleBlock: <ProbeType> {
+        name: 'Rectangle Block',
+        icon: 'mdi-rectangle',
+        description: 'Finds the center of a rectangular block (positive feature or workpiece) by probing its outer surfaces.',
+        code: 6503.1,
+        settings: {
+            'width': {
+                type: 'number',
+                label: 'Width (on X axis)',
+                description: 'The approximate width of the block (measured parallel to the X axis).',
+                parameter: 'H',
+                icon: 'mdi-unfold-more-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'length': {
+                type: 'number',
+                label: 'Length (on Y axis)',
+                description: 'The approximate length of the block (measured parallel to the Y axis).',
+                parameter: 'I',
+                icon: 'mdi-unfold-more-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm'
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_CORNER_CLEARANCE]: valueSettings[DS_CORNER_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    web: <ProbeType> {
+        name: 'Web',
+        icon: 'mdi-math-norm-box',
+        description: 'Finds the center of a web (positive rectangular feature) on one axis by probing its outer surfaces.',
+        code: 6504.1,
+        settings: {
+            [DS_QUICK]: valueSettings[DS_QUICK],
+            'axis': {
+                type: 'enum',
+                label: 'Axis',
+                description: 'The axis of the web.',
+                parameter: 'N',
+                icon: 'mdi-axis-arrow',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-swap-horizontal',
+                        label: 'X'
+                    },
+                    {
+                        icon: 'mdi-swap-vertical',
+                        label: 'Y'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate width of the web. This is how far outwards along the probed axis we will move before probing back towards the web surfaces.',
+                parameter: 'H',
+                icon: 'mdi-unfold-less-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the web surfaces. With quick mode disabled, this is used to calculate the probe locations on the web surfaces.',
+                parameter: 'I',
+                icon: 'mdi-unfold-less-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_EDGE_CLEARANCE]: valueSettings[DS_EDGE_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        }
+    },
+    pocket: <ProbeType> {
+        name: 'Pocket',
+        icon: 'mdi-math-norm',
+        description: 'Finds the center of a pocket (negative rectangular feature) on one axis by probing its inner surfaces.',
+        code: 6505.1,
+        settings: {
+            [DS_QUICK]: valueSettings[DS_QUICK],
+            'axis': {
+                type: 'enum',
+                label: 'Axis',
+                description: 'The axis of the pocket.',
+                parameter: 'N',
+                icon: 'mdi-axis-arrow',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-swap-horizontal',
+                        label: 'X'
+                    },
+                    {
+                        icon: 'mdi-swap-vertical',
+                        label: 'Y'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate width of the pocket. This defines how far outwards we expect the probed surfaces to be from the start point, minus the clearance distance.',
+                parameter: 'H',
+                icon: 'mdi-unfold-less-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the pocket surfaces. With quick mode disabled, this is used to calculate the probe locations on the pocket surfaces.',
+                parameter: 'I',
+                icon: 'mdi-unfold-less-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_EDGE_CLEARANCE]: valueSettings[DS_EDGE_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        }
+    },
+    outsideCorner: <ProbeType> {
+        name: 'Outside Corner',
+        icon: 'mdi-square-rounded-badge',
+        description: 'Finds the corner of a positive feature or workpiece by probing its outer surfaces.',
+        code: 6508.1,
+        // G6508.1 W{var.workOffset} Q{var.mode} H{var.xSL} I{var.ySL} N{var.cnr} T{var.SurfaceClearance} C{var.cornerClearance} O{var.overtravel} J{global.mosMI[0]} K{global.mosMI[1]} L{global.mosMI[2] - var.probingDepth}
+        settings: {
+            [DS_QUICK]: { ...valueSettings[DS_QUICK], value: false },
+            'corner': {
+                type: 'enum',
+                label: 'Corner',
+                description: 'The corner of the workpiece.',
+                parameter: 'N',
+                icon: 'mdi-rounded-corner',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-arrow-bottom-left-bold-box',
+                        label: 'Front Left'
+                    },
+                    {
+                        icon: 'mdi-arrow-bottom-right-bold-box',
+                        label: 'Front Right'
+                    },
+                    {
+                        icon: 'mdi-arrow-top-right-bold-box',
+                        label: 'Back Right'
+                    },
+                    {
+                        icon: 'mdi-arrow-top-left-bold-box',
+                        label: 'Back Left'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate length of the X surface of the corner.',
+                parameter: 'H',
+                icon: 'mdi-unfold-more-vertical',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the Y surface of the corner.',
+                parameter: 'I',
+                icon: 'mdi-unfold-more-horizontal',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from starting position)',
+                description: 'How far to move down from the starting position before probing.',
+                parameter: 'Z',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                multiplier: -1,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_CORNER_CLEARANCE]: valueSettings[DS_CORNER_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    viseCorner: <ProbeType> {
+        name: 'Vise Corner',
+        icon: 'mdi-cube',
+        description: 'Finds the top and corner of a positive feature or workpiece by probing its top and outer surfaces.',
+        code: 6520.1,
+        settings: {
+            [DS_QUICK]: valueSettings[DS_QUICK],
+            'corner': {
+                type: 'enum',
+                label: 'Corner',
+                description: 'The corner of the workpiece.',
+                parameter: 'N',
+                icon: 'mdi-rounded-corner',
+                value: 0,
+                options: [
+                    {
+                        icon: 'mdi-arrow-bottom-left-bold-box',
+                        label: 'Front Left'
+                    },
+                    {
+                        icon: 'mdi-arrow-bottom-right-bold-box',
+                        label: 'Front Right'
+                    },
+                    {
+                        icon: 'mdi-arrow-top-right-bold-box',
+                        label: 'Back Right'
+                    },
+                    {
+                        icon: 'mdi-arrow-top-left-bold-box',
+                        label: 'Back Left'
+                    }
+                ]
+            },
+            'width': {
+                type: 'number',
+                label: 'Width',
+                description: 'The approximate length of the X surface of the corner.',
+                icon: 'mdi-unfold-more-vertical',
+                parameter: 'H',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'length': {
+                type: 'number',
+                label: 'Length',
+                description: 'The approximate length of the Y surface of the corner.',
+                icon: 'mdi-unfold-more-horizontal',
+                parameter: 'I',
+                value: 10,
+                min: 0,
+                max: 300,
+                step: 0.1,
+                unit: 'mm',
+                condition: 'quick',
+                conditionValue: false,
+            },
+            'depth': {
+                type: 'number',
+                label: 'Depth (from top surface)',
+                description: 'How far to move down from the top surface of the corner before probing the sides.',
+                parameter: 'P',
+                icon: 'mdi-arrow-down-bold-circle',
+                value: 5,
+                min: 0,
+                max: 20,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_SURFACE_CLEARANCE]: valueSettings[DS_SURFACE_CLEARANCE],
+            [DS_CORNER_CLEARANCE]: valueSettings[DS_CORNER_CLEARANCE],
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    },
+    singleSurface: <ProbeType> {
+        name: 'Single Surface',
+        icon: 'mdi-square-opacity',
+        description: 'Finds the co-ordinate of a surface at one point.',
+        code: 6510.1,
+        settings: {
+            'surface': {
+                type: 'enum',
+                label: 'Surface',
+                description: 'The surface s towards the..',
+                parameter: 'H',
+                icon: 'mdi-square-opacity',
+                value: 0,
+                options: [
+                    {
+                        label: 'Left',
+                        icon: 'mdi-arrow-left-bold'
+                    },
+                    {
+                        label: 'Right',
+                        icon: 'mdi-arrow-right-bold'
+                    },
+                    {
+                        label: 'Front',
+                        icon: 'mdi-arrow-down-bold'
+                    },
+                    {
+                        label: 'Back',
+                        icon: 'mdi-arrow-up-bold'
+                    },
+                    {
+                        label: 'Top',
+                        icon: 'mdi-circle-box'
+                    }
+                ]
+            },
+            'distance': {
+                type: 'number',
+                label: 'Distance',
+                description: 'The approximate distance to move towards the target surface.',
+                icon: 'mdi-ruler',
+                parameter: 'I',
+                value: 10,
+                min: 1,
+                max: 100,
+                step: 0.1,
+                unit: 'mm'
+            },
+            [DS_OVERTRAVEL]: valueSettings[DS_OVERTRAVEL]
+        },
+    }
+} as ProbeTypes;

--- a/ui/src/utils/display.ts
+++ b/ui/src/utils/display.ts
@@ -1,0 +1,8 @@
+import Vue from "vue";
+
+export const workplaceAsGCode = function(workplace: number): string {
+    return 'G' + ((workplace < 6) ? 54 + workplace : 59 + ((workplace % 5) * 0.1)).toString();
+}
+
+// Register display extensions
+Vue.prototype.$workplaceAsGCode = workplaceAsGCode;

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -1,0 +1,1 @@
+import './display';


### PR DESCRIPTION
Duet Web Control plugins can contain files that are just extracted to the SD card. We can use this to install MillenniumOS and the UI side-by-side, which should make versioning and interaction between the UI and MillenniumOS itself easier to track.

This commit does _not_ currently make a SD-card release which can install the UI plugin - it is copied to the SD card but is not loaded into DWC correctly (WIP)