### PR TITLE
Only read the G6508.1 H & L parameters in full mode

### DIFF
--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -79,10 +79,9 @@ var sY   = { param.K }
 
 
 ; Length of surfaces on X and Y forming the corner
-; These will be null when using quick mode so
-; _always_ check for var.pMO == 0 before using these.
-var fX   = { param.H }
-var fY   = { param.I }
+; These are 0 when using quick mode
+var fX   = { (var.pFull) ? param.H : 0 }
+var fY   = { (var.pFull) ? param.I : 0 }
 
 ; Tool Radius is the first entry for each value in
 ; our extended tool table.


### PR DESCRIPTION
Fixes the following error in MillenniumOS v0.5.0-rc10 :

G6508.1 Q1 N0 Z-50 T10 C5 O2 J394.9766714 K175.0277782 L-40 R0
Resetting WCS 1 probed corner
Resetting WCS 1 probed dimensions
Resetting WCS 1 probed rotation
Error: in file macro line 84 column 22: meta command: unknown parameter 'H'