### PR TITLE
Fix quick mode / full mode vice corner issues

### DIFF
--- a/macro/movement/G6508.1.g
+++ b/macro/movement/G6508.1.g
@@ -16,7 +16,7 @@ if { !exists(param.J) || !exists(param.K) || !exists(param.L) }
 if { !exists(param.Z) }
     abort { "Must provide a probe position using the Z parameter!" }
 
-if { (!exists(param.Q) || param.Q == 0) && (!exists(param.H) || !exists(param.I)) }
+if { (!exists(param.Q) || param.Q == 0) && (!exists(param.H) || !exists(param.I) || param.H == null || param.I == null) }
     abort { "Must provide an approximate X length and Y length using H and I parameters when using full probe, Q0!" }
 
 ; Maximum of 4 corners (0..3)
@@ -79,9 +79,12 @@ var sY   = { param.K }
 
 
 ; Length of surfaces on X and Y forming the corner
-; These are 0 when using quick mode
-var fX   = { (var.pFull) ? param.H : 0 }
-var fY   = { (var.pFull) ? param.I : 0 }
+; These are null when in quick mode, as using 0 could
+; lead to unintended maths consequences. It is invalid
+; to use these values in quick mode so we should always
+; error out if they are used.
+var fX   = { (var.pFull) ? param.H : null }
+var fY   = { (var.pFull) ? param.I : null }
 
 ; Tool Radius is the first entry for each value in
 ; our extended tool table.

--- a/macro/movement/G6520.1.g
+++ b/macro/movement/G6520.1.g
@@ -67,7 +67,7 @@ if { global.mosWPSfcPos[var.workOffset] == global.mosDfltWPSfcPos || global.mosW
 M5000 P1 I2
 
 ; Probe the corner surface
-G6508.1 R0 W{var.workOffset} Q{param.Q} H{param.H} I{param.I} N{param.N} T{param.T} C{param.C} O{param.O} J{param.J} K{param.K} L{ global.mosMI } Z{global.mosWPSfcPos[var.workOffset] - param.P }
+G6508.1 R0 W{var.workOffset} Q{param.Q} H{exists(param.H) ? param.H : null} I{exists(param.I) ? param.I : null} N{param.N} T{param.T} C{param.C} O{param.O} J{param.J} K{param.K} L{ global.mosMI } Z{global.mosWPSfcPos[var.workOffset] - param.P }
 if { global.mosWPCnrNum[var.workOffset] == null }
     abort { "G6520: Failed to probe the corner surface of the workpiece!" }
 


### PR DESCRIPTION
Hi @HannahKiekens, thanks for bringing the Outside Corner / Vice Corner Quick Mode issues to my attention.

I have taken a slightly different approach for fixing the quick mode vice corner issue as I would prefer to keep this as a single call to the underlying macro, for consistency with the other macros.

I have also switched to using `null` instead of `0` for missing width and height values as I find this preferable as it will never accidentally work in the context of any maths that occurs outside of the full mode block.

I have not had a chance to test this so would appreciate any input if possible, otherwise I will try to get this tested and merged as soon as I can.

Thanks for your help :+1: 